### PR TITLE
[script] lint-whitespace: improve print linenumber

### DIFF
--- a/contrib/devtools/lint-whitespace.sh
+++ b/contrib/devtools/lint-whitespace.sh
@@ -37,20 +37,25 @@ if showdiff | grep -E -q '^\+.*\s+$'; then
   echo "The following changes were suspected:"
   FILENAME=""
   SEEN=0
+  SEENLN=0
   while read -r line; do
     if [[ "$line" =~ ^diff ]]; then
       FILENAME="$line"
       SEEN=0
     elif [[ "$line" =~ ^@@ ]]; then
       LINENUMBER="$line"
+      SEENLN=0
     else
       if [ "$SEEN" -eq 0 ]; then
         # The first time a file is seen with trailing whitespace, we print the
         # filename (preceded by a newline).
         echo
         echo "$FILENAME"
-        echo "$LINENUMBER"
         SEEN=1
+      fi
+      if [ "$SEENLN" -eq 0 ]; then
+        echo "$LINENUMBER"
+        SEENLN=1
       fi
       echo "$line"
     fi
@@ -64,20 +69,25 @@ if showcodediff | grep -P -q '^\+.*\t'; then
   echo "The following changes were suspected:"
   FILENAME=""
   SEEN=0
+  SEENLN=0
   while read -r line; do
     if [[ "$line" =~ ^diff ]]; then
       FILENAME="$line"
       SEEN=0
     elif [[ "$line" =~ ^@@ ]]; then
       LINENUMBER="$line"
+      SEENLN=0
     else
       if [ "$SEEN" -eq 0 ]; then
         # The first time a file is seen with a tab character, we print the
         # filename (preceded by a newline).
         echo
         echo "$FILENAME"
-        echo "$LINENUMBER"
         SEEN=1
+      fi
+      if [ "$SEENLN" -eq 0 ]; then
+        echo "$LINENUMBER"
+        SEENLN=1
       fi
       echo "$line"
     fi


### PR DESCRIPTION
Before this PR, the linenumber infomaition is output if trailing-space
or tab code was found, but the output occurence is only per a file.
This PR separates the output timing of file name and line number.
As a result, users will find where they need to fix more easily.