### PR TITLE
Split sentinel expiration in CMasternode::Check() in two parts (timeo…

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -219,10 +219,10 @@ void CMasternode::Check(bool fForce)
             return;
         }
 
+        // part 1: expire based on dashd ping
         bool fSentinelPingActive = masternodeSync.IsSynced() && mnodeman.IsSentinelPingActive();
-        bool fSentinelPingExpired = fSentinelPingActive && (!lastPing.fSentinelIsCurrent || !IsPingedWithin(MASTERNODE_SENTINEL_PING_MAX_SECONDS));
-
-        LogPrint(BCLog::MNODE, "CMasternode::Check -- outpoint=%s, GetAdjustedTime()=%d, fSentinelPingExpired=%d\n",
+        bool fSentinelPingExpired = fSentinelPingActive && !IsPingedWithin(MASTERNODE_SENTINEL_PING_MAX_SECONDS);
+                LogPrint(BCLog::MNODE, "CMasternode::Check -- outpoint=%s, GetAdjustedTime()=%d, fSentinelPingExpired=%d\n",
                 outpoint.ToStringShort(), GetAdjustedTime(), fSentinelPingExpired);
 
         if(fSentinelPingExpired) {
@@ -234,13 +234,30 @@ void CMasternode::Check(bool fForce)
         }
     }
 
-    // Allow MNs to become ENABLED immediately in regtest/devnet
+    // Allow MNs to become PRE_ENABLED immediately in regtest/devnet
     // On mainnet/testnet, we require them to be in PRE_ENABLED state for some time before they get into ENABLED state
     if (Params().NetworkIDString() != CBaseChainParams::REGTEST) {
         if (lastPing.sigTime - sigTime < MASTERNODE_MIN_MNP_SECONDS) {
             nActiveState = MASTERNODE_PRE_ENABLED;
             if (nActiveStatePrev != nActiveState) {
                 LogPrint(BCLog::MNODE, "CMasternode::Check -- Masternode %s is in %s state now\n", outpoint.ToStringShort(), GetStateString());
+            }
+            return;
+        }
+    }
+
+    if(!fWaitForPing || fOurMasternode) {
+        // part 2: expire based on sentinel info
+        bool fSentinelPingActive = masternodeSync.IsSynced() && mnodeman.IsSentinelPingActive();
+        bool fSentinelPingExpired = fSentinelPingActive && !lastPing.fSentinelIsCurrent;
+
+        LogPrint("masternode", "CMasternode::Check -- outpoint=%s, GetAdjustedTime()=%d, fSentinelPingExpired=%d\n",
+                outpoint.ToStringShort(), GetAdjustedTime(), fSentinelPingExpired);
+
+        if(fSentinelPingExpired) {
+            nActiveState = MASTERNODE_SENTINEL_PING_EXPIRED;
+            if(nActiveStatePrev != nActiveState) {
+                LogPrint("masternode", "CMasternode::Check -- Masternode %s is in %s state now\n", outpoint.ToStringShort(), GetStateString());
             }
             return;
         }


### PR DESCRIPTION
…ut and version) (#2121)

The initial ping is sent with defaults which switch MNs to SENTINEL_PING_EXPIRED state
while they should really be in PRE_ENABLED state. The fix is to split this verification
in two parts - this way sentinel version is only checked after at least one ping is received
from the masternode itself and not from the cold wallet.