### PR TITLE
scripted-diff: rename TestNode to TestP2PConn in tests

### DIFF
--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -15,8 +15,8 @@ from test_framework.blocktools import create_block, create_coinbase, add_witness
 from test_framework.script import CScript, OP_TRUE, OP_DROP
 
 
-# TestNode: A peer we use to send messages to bitcoind, and store responses.
-class TestNode(P2PInterface):
+# TestP2PConn: A peer we use to send messages to bitcoind, and store responses.
+class TestP2PConn(P2PInterface):
     def __init__(self):
         super().__init__()
         self.last_sendcmpct = []
@@ -790,9 +790,9 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     def run_test(self):
         # Setup the p2p connections and start up the network thread.
-        self.test_node = self.nodes[0].add_p2p_connection(TestNode())
-        self.segwit_node = self.nodes[1].add_p2p_connection(TestNode(), services=NODE_NETWORK|NODE_WITNESS)
-        self.old_node = self.nodes[1].add_p2p_connection(TestNode(), services=NODE_NETWORK)
+        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn())
+        self.segwit_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK|NODE_WITNESS)
+        self.old_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
 
         network_thread_start()
 

--- a/test/functional/p2p_feefilter.py
+++ b/test/functional/p2p_feefilter.py
@@ -22,7 +22,7 @@ def allInvsMatch(invsExpected, testnode):
         time.sleep(1)
     return False
 
-class TestNode(P2PInterface):
+class TestP2PConn(P2PInterface):
     def __init__(self):
         super().__init__()
         self.txinvs = []
@@ -51,7 +51,7 @@ class FeeFilterTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         # Setup the p2p connections and start up the network thread.
-        self.nodes[0].add_p2p_connection(TestNode())
+        self.nodes[0].add_p2p_connection(TestP2PConn())
         network_thread_start()
         self.nodes[0].p2p.wait_for_verack()
 

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -60,7 +60,7 @@ def test_witness_block(rpc, p2p, block, accepted, with_witness=True):
     p2p.sync_with_ping()
     assert_equal(rpc.getbestblockhash() == block.hash, accepted)
 
-class TestNode(P2PInterface):
+class TestP2PConn(P2PInterface):
     def __init__(self):
         super().__init__()
         self.getdataset = set()
@@ -1879,11 +1879,11 @@ class SegWitTest(BitcoinTestFramework):
     def run_test(self):
         # Setup the p2p connections and start up the network thread.
         # self.test_node sets NODE_WITNESS|NODE_NETWORK
-        self.test_node = self.nodes[0].add_p2p_connection(TestNode(), services=NODE_NETWORK|NODE_WITNESS)
+        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK|NODE_WITNESS)
         # self.old_node sets only NODE_NETWORK
-        self.old_node = self.nodes[0].add_p2p_connection(TestNode(), services=NODE_NETWORK)
+        self.old_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
         # self.std_node is for testing node1 (fRequireStandard=true)
-        self.std_node = self.nodes[1].add_p2p_connection(TestNode(), services=NODE_NETWORK|NODE_WITNESS)
+        self.std_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK|NODE_WITNESS)
 
         network_thread_start()
 

--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -27,7 +27,7 @@ from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-class TestNode(P2PInterface):
+class TestP2PConn(P2PInterface):
     def on_version(self, message):
         # Don't send a verack in response
         pass
@@ -40,9 +40,9 @@ class TimeoutsTest(BitcoinTestFramework):
 
     def run_test(self):
         # Setup the p2p connections and start up the network thread.
-        no_verack_node = self.nodes[0].add_p2p_connection(TestNode())
-        no_version_node = self.nodes[0].add_p2p_connection(TestNode(), send_version=False)
-        no_send_node = self.nodes[0].add_p2p_connection(TestNode(), send_version=False)
+        no_verack_node = self.nodes[0].add_p2p_connection(TestP2PConn())
+        no_version_node = self.nodes[0].add_p2p_connection(TestP2PConn(), send_version=False)
+        no_send_node = self.nodes[0].add_p2p_connection(TestP2PConn(), send_version=False)
 
         network_thread_start()
 

--- a/test/functional/test_framework/comptool.py
+++ b/test/functional/test_framework/comptool.py
@@ -8,7 +8,7 @@ To use, create a class that implements get_tests(), and pass it in
 as the test generator to TestManager.  get_tests() should be a python
 generator that returns TestInstance objects.  See below for definition.
 
-TestNode behaves as follows:
+TestP2PConn behaves as follows:
     Configure with a BlockStore and TxStore
     on_inv: log the message but don't request
     on_headers: log the chain tip
@@ -39,7 +39,7 @@ class RejectResult():
     def __repr__(self):
         return '%i:%s' % (self.code,self.reason or '*')
 
-class TestNode(P2PInterface):
+class TestP2PConn(P2PInterface):
 
     def __init__(self, block_store, tx_store):
         super().__init__()
@@ -170,7 +170,7 @@ class TestManager():
     def add_all_connections(self, nodes):
         for i in range(len(nodes)):
             # Create a p2p connection to each node
-            node = TestNode(self.block_store, self.tx_store)
+            node = TestP2PConn(self.block_store, self.tx_store)
             node.peer_connect('127.0.0.1', p2p_port(i))
             self.p2p_connections.append(node)
 


### PR DESCRIPTION
Several test scripts define a subclass of P2PInterface called TestNode.
This commit renames those to TestP2PConn since we already have a
TestNode class in the test framework.

-BEGIN VERIFY SCRIPT-
sed -i s/TestNode/TestP2PConn/ test/functional/*py test/functional/test_framework/comptool.py
_END VERIFY SCRIPT-