### PR TITLE
[config] Remove blockmaxsize option

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -458,10 +458,6 @@ Instant send is a functionality ported from DASH distributing a copy of desired 
 - #13246 `6de7543` Bump to Ubuntu Bionic 18.04 in build-windows.md (ken2812221)
 - #12556 `e730b82` Fix version typo in getpeerinfo RPC call help (tamasblummer)
 
-### Logging
-
-- The log timestamp format is now ISO 8601 (e.g. "2018-02-28T12:34:56Z").
-
 RPC changes
 ------------
 
@@ -511,6 +507,18 @@ Low-level RPC changes
   with any `-wallet=<path>` options, there is no change in behavior, and the
   name of any wallet is just its `<path>` string.
 
+### Logging
+
+- The log timestamp format is now ISO 8601 (e.g. "2018-02-28T12:34:56Z").
+
+Miner block size removed
+
+The `-blockmaxsize` option for miners to limit their blocks' sizes was
+deprecated in V0.15.1, and has now been removed. Miners should use the
+`-blockmaxweight` option if they want to limit the weight of their blocks'
+weights.
+
+>>>>>>> 4757c04cb... [config] Remove blockmaxsize option
 Credits
 =======
 

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -133,8 +133,8 @@ class EstimateFeeTest(BitcoinTestFramework):
         which we will use to generate our transactions.
         """
         self.add_nodes(3, extra_args=[["-maxorphantx=1000", "-whitelist=127.0.0.1"],
-                                      ["-blockmaxsize=17000", "-maxorphantx=1000"],
-                                      ["-blockmaxsize=8000", "-maxorphantx=1000"]])
+                                      ["-maxorphantx=1000"],
+                                      ["-maxorphantx=1000"]])
         # Use node0 to mine blocks for input splitting
         # Node1 mines small blocks but that are bigger than the expected transaction rate.
         # NOTE: the CreateNewBlock code starts counting block size at 1,000 bytes,


### PR DESCRIPTION
The blockmaxsize option was marked as deprecated in V0.15.1, and code
was added to convert provided blockmaxsize into blockmaxweight. However,
this code was incorrectly implemented, and blockmaxsize was silently
ignored.

No users have complained about blockmaxsize being ignored, so just
remove it in V0.17.