### PR TITLE
test: Remove travis checkout depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ cache:
   - depends/built
   - depends/sdk-sources
   - $HOME/.ccache
-git:
-  depth: 1
 env:
   global:
     - MAKEJOBS=-j3


### PR DESCRIPTION
Tests on branches of non-head commits are failing, because the depth of
1 doesn't allow checking them out.

Remove `depth` as was the case before fa44af5cd2152a21da9ef3e48c073a668bf2df27,
so that Travis can determine the minimum depth to check out.