### PR TITLE
[Tests] fix a typo in TestNode.assert_start_raises_init_error()

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -31,6 +31,11 @@ JSONDecodeError = getattr(json, "JSONDecodeError", ValueError)
 
 BITCOIND_PROC_WAIT_TIMEOUT = 60
 
+
+class FailedToStartError(Exception):
+    """Raised when a node fails to start correctly."""
+
+
 class TestNode():
     """A class for representing a bitcoind node under test.
 
@@ -118,7 +123,8 @@ class TestNode():
         # Poll at a rate of four times per second
         poll_per_s = 4
         for _ in range(poll_per_s * self.rpc_timeout):
-            assert self.process.poll() is None, "bitcoind exited with status %i during initialization" % self.process.returncode
+            if self.process.poll() is not None:
+                raise FailedToStartError('bitcoind exited with status {} during initialization'.format(self.process.returncode))
             try:
                 self.rpc = get_rpc_proxy(rpc_url(self.datadir, self.index, self.rpchost), self.index, timeout=self.rpc_timeout, coveragedir=self.coverage_dir)
                 self.rpc.getblockcount()
@@ -195,9 +201,9 @@ class TestNode():
                 self.start(extra_args, stderr=log_stderr, *args, **kwargs)
                 self.wait_for_rpc_connection()
                 self.stop_node()
-                self.wait_util_stopped()
-            except Exception as e:
-                assert 'bitcoind exited' in str(e)  # node must have shutdown
+                self.wait_until_stopped()
+            except FailedToStartError as e:
+                self.log.debug('bitcoind failed to start: %s', e)
                 self.running = False
                 self.process = None
                 # Check stderr for expected message


### PR DESCRIPTION
Also, use specific exception for testing TestNode initialization failure.