### PR TITLE
contrib: Fix check-doc script regexes

### DIFF
--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -16,31 +16,33 @@ import sys
 
 FOLDER_GREP = 'src'
 FOLDER_TEST = 'src/test/'
+REGEX_ARG = '(?:ForceSet|SoftSet|Get|Is)(?:Bool)?Args?(?:Set)?\("(-[^"]+)"'
+REGEX_DOC = 'HelpMessageOpt\("(-[^"=]+?)(?:=|")'
 CMD_ROOT_DIR = '`git rev-parse --show-toplevel`/{}'.format(FOLDER_GREP)
-CMD_GREP_ARGS = r"egrep -r -I '(map(Multi)?Args(\.count\(|\[)|Get(Bool)?Arg\()\"\-[^\"]+?\"' {} | grep -v '{}'".format(CMD_ROOT_DIR, FOLDER_TEST)
-CMD_GREP_DOCS = r"egrep -r -I 'HelpMessageOpt\(\"\-[^\"=]+?(=|\")' {}".format(CMD_ROOT_DIR)
-REGEX_ARG = re.compile(r'(?:map(?:Multi)?Args(?:\.count\(|\[)|Get(?:Bool)?Arg\()\"(\-[^\"]+?)\"')
-REGEX_DOC = re.compile(r'HelpMessageOpt\(\"(\-[^\"=]+?)(?:=|\")')
+CMD_GREP_ARGS = r"git grep --perl-regexp '{}' -- {} ':(exclude){}'".format(REGEX_ARG, CMD_ROOT_DIR, FOLDER_TEST)
+CMD_GREP_DOCS = r"git grep --perl-regexp '{}' {}".format(REGEX_DOC, CMD_ROOT_DIR)
 # list unsupported, deprecated and duplicate args as they need no documentation
 SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize', '-dbcrashratio', '-forcecompactdb', '-usehd'])
 
+
 def main():
-  used = check_output(CMD_GREP_ARGS, shell=True, universal_newlines=True)
-  docd = check_output(CMD_GREP_DOCS, shell=True, universal_newlines=True)
+    used = check_output(CMD_GREP_ARGS, shell=True, universal_newlines=True)
+    docd = check_output(CMD_GREP_DOCS, shell=True, universal_newlines=True)
 
-  args_used = set(re.findall(REGEX_ARG,used))
-  args_docd = set(re.findall(REGEX_DOC,docd)).union(SET_DOC_OPTIONAL)
-  args_need_doc = args_used.difference(args_docd)
-  args_unknown = args_docd.difference(args_used)
+    args_used = set(re.findall(re.compile(REGEX_ARG), used))
+    args_docd = set(re.findall(re.compile(REGEX_DOC), docd)).union(SET_DOC_OPTIONAL)
+    args_need_doc = args_used.difference(args_docd)
+    args_unknown = args_docd.difference(args_used)
 
-  print("Args used        : {}".format(len(args_used)))
-  print("Args documented  : {}".format(len(args_docd)))
-  print("Args undocumented: {}".format(len(args_need_doc)))
-  print(args_need_doc)
-  print("Args unknown     : {}".format(len(args_unknown)))
-  print(args_unknown)
+    print("Args used        : {}".format(len(args_used)))
+    print("Args documented  : {}".format(len(args_docd)))
+    print("Args undocumented: {}".format(len(args_need_doc)))
+    print(args_need_doc)
+    print("Args unknown     : {}".format(len(args_unknown)))
+    print(args_unknown)
 
-  sys.exit(len(args_need_doc))
+    sys.exit(len(args_need_doc))
+
 
 if __name__ == "__main__":
     main()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -460,8 +460,7 @@ std::string HelpMessage(HelpMessageMode mode)
 #endif
 
     strUsage += HelpMessageGroup(_("Debugging/Testing options:"));
-    if (showDebug)
-    {
+    if (showDebug) {
         strUsage += HelpMessageOpt("-checkblocks=<n>", strprintf(_("How many blocks to check at startup (default: %u, 0 = all)"), DEFAULT_CHECKBLOCKS));
         strUsage += HelpMessageOpt("-checklevel=<n>", strprintf(_("How thorough the block verification of -checkblocks is (0-4, default: %u)"), DEFAULT_CHECKLEVEL));
         strUsage += HelpMessageOpt("-checkblockindex", strprintf("Do a full consistency check for mapBlockIndex, setBlockIndexCandidates, chainActive and mapBlocksUnlinked occasionally. (default: %u)", defaultChainParams->DefaultConsistencyChecks()));
@@ -471,7 +470,6 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-deprecatedrpc=<method>", "Allows deprecated RPC method(s) to be used");
         strUsage += HelpMessageOpt("-testsafemode", strprintf("Force safe mode (default: %u)", DEFAULT_TESTSAFEMODE));
         strUsage += HelpMessageOpt("-dropmessagestest=<n>", "Randomly drop 1 of every <n> network messages");
-        strUsage += HelpMessageOpt("-fuzzmessagestest=<n>", "Randomly fuzz 1 of every <n> network messages");
         strUsage += HelpMessageOpt("-stopafterblockimport", strprintf("Stop running after importing blocks from disk (default: %u)", DEFAULT_STOPAFTERBLOCKIMPORT));
         strUsage += HelpMessageOpt("-stopatheight", strprintf("Stop running after reaching the given height in the main chain (default: %u)", DEFAULT_STOPATHEIGHT));
 


### PR DESCRIPTION
Fixup the regexes to properly find all used args. The regex should now match all of the getter and setter methods of the `ArgsManager`. See https://dev.visucore.com/bitcoin/doxygen/class_args_manager.html#pub-methods

Before:
```
Args used : 159
Args documented : 188
Args undocumented: 0
Args unknown : 29
```

After:
```
Args used : 183
Args documented : 188
Args undocumented: 0
Args unknown : 5
```