### PR TITLE
tests: Add note about test suite naming convention in developer-notes.md

### DIFF
--- a/contrib/devtools/lint-tests.sh
+++ b/contrib/devtools/lint-tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check the test suite naming convention
+
+NAMING_INCONSISTENCIES=$(git grep -E '^BOOST_FIXTURE_TEST_SUITE\(' -- \
+    "src/test/**.cpp" "src/wallet/test/**.cpp" | \
+    grep -vE '/(.*?)\.cpp:BOOST_FIXTURE_TEST_SUITE\(\1, .*\)$')
+if [[ ${NAMING_INCONSISTENCIES} != "" ]]; then
+    echo "The test suite in file src/test/foo_tests.cpp should be named"
+    echo "\"foo_tests\". Please make sure the following test suites follow"
+    echo "that convention:"
+    echo
+    echo "${NAMING_INCONSISTENCIES}"
+    exit 1
+fi

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -71,6 +71,8 @@ code.
   - Constant names are all uppercase, and use `_` to separate words.
   - Class names, function names and method names are UpperCamelCase
     (PascalCase). Do not prefix class names with `C`.
+  - Test suite naming convention: The Boost test suite in file
+    `src/test/foo_tests.cpp` should be named `foo_tests`.
 
 - **Miscellaneous**
   - `++i` is preferred over `i++`.

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -54,7 +54,7 @@ void TestDifficulty(uint32_t nbits, double expected_difficulty)
     RejectDifficultyMismatch(difficulty, expected_difficulty);
 }
 
-BOOST_FIXTURE_TEST_SUITE(blockchain_difficulty_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(blockchain_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(get_difficulty_for_very_low_target)
 {

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(PrevectorTests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(prevector_tests, TestingSetup)
 
 template<unsigned int N, typename T>
 class prevector_tester {

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -67,7 +67,7 @@ public:
 
 typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;
 
-namespace wallet_crypto
+namespace crypto_tests
 {
     class TestCrypter;
 }
@@ -75,7 +75,7 @@ namespace wallet_crypto
 /** Encryption/decryption context with key information */
 class CCrypter
 {
-friend class wallet_crypto::TestCrypter; // for test access to chKey/chIV
+friend class crypto_tests::TestCrypter; // for test access to chKey/chIV
 private:
 std::vector<unsigned char, secure_allocator<unsigned char>> vchKey;
 std::vector<unsigned char, secure_allocator<unsigned char>> vchIV;

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -14,7 +14,7 @@
 #include <boost/test/unit_test.hpp>
 #include <random>
 
-BOOST_FIXTURE_TEST_SUITE(coin_selection_tests, WalletTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(coinselector_tests, WalletTestingSetup)
 
 // how many times to run all the tests to have a chance to catch errors that only show up with particular random shuffles
 #define RUN_TESTS 100

--- a/src/wallet/test/crypto_tests.cpp
+++ b/src/wallet/test/crypto_tests.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(wallet_crypto, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(crypto_tests, BasicTestingSetup)
 
 class TestCrypter
 {


### PR DESCRIPTION
Changes:
* Add note about test suite naming convention
* Fix exceptions
* Add regression test

Rationale:
* Consistent naming of test suites makes programmatic test running of specific tests/subsets of tests easier
* Explicit is better than implicit

Before this commit:

```
$ contrib/devtools/lint-tests.sh
The test suite in file src/test/foo_tests.cpp should be named
"foo_tests". Please make sure the following test suites follow
that convention:

src/test/blockchain_tests.cpp:BOOST_FIXTURE_TEST_SUITE(blockchain_difficulty_tests, BasicTestingSetup)
src/test/prevector_tests.cpp:BOOST_FIXTURE_TEST_SUITE(PrevectorTests, TestingSetup)
src/wallet/test/coinselector_tests.cpp:BOOST_FIXTURE_TEST_SUITE(coin_selection_tests, WalletTestingSetup)
src/wallet/test/crypto_tests.cpp:BOOST_FIXTURE_TEST_SUITE(wallet_crypto, BasicTestingSetup)
$
```

After this commit:

```
$ contrib/devtools/lint-tests.sh
$
```
