### PR TITLE
[arith_uint256] Make it safe to use "self" in operators

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -69,16 +69,16 @@ base_uint<BITS>& base_uint<BITS>::operator*=(uint32_t b32)
 template <unsigned int BITS>
 base_uint<BITS>& base_uint<BITS>::operator*=(const base_uint& b)
 {
-    base_uint<BITS> a = *this;
-    *this = 0;
+    base_uint<BITS> a;
     for (int j = 0; j < WIDTH; j++) {
         uint64_t carry = 0;
         for (int i = 0; i + j < WIDTH; i++) {
-            uint64_t n = carry + pn[i + j] + (uint64_t)a.pn[j] * b.pn[i];
-            pn[i + j] = n & 0xffffffff;
+            uint64_t n = carry + a.pn[i + j] + (uint64_t)pn[j] * b.pn[i];
+            a.pn[i + j] = n & 0xffffffff;
             carry = n >> 32;
         }
     }
+    *this = a;
     return *this;
 }
 

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -266,4 +266,17 @@ BOOST_AUTO_TEST_CASE( conversion )
     BOOST_CHECK(R2L.GetHex() == UintToArith256(R2L).GetHex());
 }
 
+BOOST_AUTO_TEST_CASE( operator_with_self )
+{
+    arith_uint256 v = UintToArith256(uint256S("02"));
+    v *= v;
+    BOOST_CHECK(v == UintToArith256(uint256S("04")));
+    v /= v;
+    BOOST_CHECK(v == UintToArith256(uint256S("01")));
+    v += v;
+    BOOST_CHECK(v == UintToArith256(uint256S("02")));
+    v -= v;
+    BOOST_CHECK(v == UintToArith256(uint256S("0")));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Before this fix (see test commit), `v *= v` would result in `0` because `operator*=` set `*this` (`==b`) to `0` at the start. This patch changes the code to use `a` as temporary for `*this`~~, with drawback that `*this` is set to `a` at the end, an extra `=` operation in other words~~.