### PR TITLE
Fixed links and verbiage

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,6 @@
-<!-- This issue tracker is only for technical issues related to Bitcoin Core.
+<!-- This issue tracker is only for technical issues related to Chaincoin Core.
 
-General bitcoin questions and/or support requests are best directed to the Bitcoin StackExchange at https://bitcoin.stackexchange.com.
-
-For reporting security issues, please read instructions at https://bitcoincore.org/en/contact/.
+General chaincoin questions and/or support requests are best directed to the Chaincoin Discord at https://discord.gg/NabdcJ7.
 
 If the node is "stuck" during sync or giving "block checksum mismatch" errors, please ensure your hardware is stable by running memtest and observe CPU temperature with a load-test tool such as linpack before creating an issue! -->
 
@@ -13,7 +11,7 @@ If the node is "stuck" during sync or giving "block checksum mismatch" errors, p
 
 <!--- How reliably can you reproduce the issue, what are the steps to do so? -->
 
-<!-- What version of Bitcoin Core are you using, where did you get it (website, self-compiled, etc)? -->
+<!-- What version of Chaincoin Core are you using, where did you get it (website, self-compiled, etc)? -->
 
 <!-- What type of machine are you observing the error on (OS/CPU and disk type)? -->
 

--- a/INSTALL
+++ b/INSTALL
@@ -21,7 +21,7 @@ use the autogen script to prepare the build environment.
     make
 
 Precompiled binaries are available at github, see
-https://github.com/ChainCoinUnlimited/chaincoin-binaries
+https://github.com/chaincoin/chaincoin/releases
 
 Always verify the signatures and checksums.
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ information or see https://opensource.org/licenses/MIT.
 Development Process
 -------------------
 
-The `master` branch is meant to be stable. Development is normally done in separate branches.
-[Tags](https://github.com/ChainCoinUnlimited/chaincoin/tags) are created to indicate new official,
-stable release versions of Chaincoin Core.
+The `master` branch is regularly built and tested, but is not guaranteed to be completely stable. [Tags](https://github.com/chaincoin/chaincoin/tags) are created
+regularly to indicate new official, stable release versions of Chaincoin Core.
 
 The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -3,9 +3,9 @@ Chaincoin Core
 
 Setup
 ---------------------
-Chaincoin Core is the original Chaincoin client and it builds the backbone of the network. It downloads and, by default, stores the entire history of Chaincoin transactions (which is currently more than 100 GBs); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
+Chaincoin Core is the original Chaincoin client and it builds the backbone of the network. It downloads and, by default, stores the entire history of Chaincoin transactions (which is currently more than 1 GB); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
 
-To download Chaincoin Core, visit [chaincoincore.org](https://chaincoincore.org/releases/).
+To download Chaincoin Core, visit [chaincoin.org](https://www.chaincoin.org/chaincoin-wallet/).
 
 Running
 ---------------------

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,6 +1,6 @@
 Chaincoin Core version 0.16.1 is now available from:
 
-  <https://chaincoin.org/bin/chaincoin-core-0.16.1/>
+  <https://github.com/chaincoin/chaincoin/releases/tag/v0.16.1/>
 
 This is a new major version release, including new features, various bugfixes
 and performance improvements, as well as updated translations.


### PR DESCRIPTION
- Updated ISSUE_TEMPLATE
- Updated INSTALL: fixed link to the correct release location
- Fixed README: reflect current Chaincoin's development process (the 
same way Bitcoin core does)
- Updated doc/README: corrected current blockchain size, download link
- Updated release-notes: corrected 0.16.1 download link