### PR TITLE
Support serialization as another type without casting

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -59,7 +59,7 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(*static_cast<CAddress*>(this));
+        READWRITEAS(CAddress, *this);
         READWRITE(source);
         READWRITE(nLastSuccess);
         READWRITE(nAttempts);

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -96,7 +96,7 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(*static_cast<CBlockHeader*>(this));
+        READWRITEAS(CBlockHeader, *this);
         READWRITE(vtx);
     }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -371,7 +371,7 @@ public:
         uint64_t nServicesInt = nServices;
         READWRITE(nServicesInt);
         nServices = static_cast<ServiceFlags>(nServicesInt);
-        READWRITE(*static_cast<CService*>(this));
+        READWRITEAS(CService, *this);
     }
 
     // TODO: make private (improves encapsulation)

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -415,7 +415,7 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(static_cast<CScriptBase&>(*this));
+        READWRITEAS(CScriptBase, *this);
     }
 
     CScript& operator+=(const CScript& b)

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -167,7 +167,12 @@ enum
     SER_GETHASH         = (1 << 2),
 };
 
-#define READWRITE(...)      (::SerReadWriteMany(s, ser_action, __VA_ARGS__))
+//! Convert the reference base type to X, without changing constness or reference type.
+template<typename X> X& ReadWriteAsHelper(X& x) { return x; }
+template<typename X> const X& ReadWriteAsHelper(const X& x) { return x; }
+
+#define READWRITE(...) (::SerReadWriteMany(s, ser_action, __VA_ARGS__))
+#define READWRITEAS(type, obj) (::SerReadWriteMany(s, ser_action, ReadWriteAsHelper<type>(obj)))
 
 /**
  * Implement three methods for serializable objects. These are actually wrappers over

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -47,7 +47,7 @@ struct CDiskTxPos : public CDiskBlockPos
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(*static_cast<CDiskBlockPos*>(this));
+        READWRITEAS(CDiskBlockPos, *this);
         READWRITE(VARINT(nTxOffset));
     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -430,7 +430,7 @@ public:
             mapValueCopy["timesmart"] = strprintf("%u", nTimeSmart);
         }
 
-        s << *static_cast<const CMerkleTx*>(this);
+        s << static_cast<const CMerkleTx&>(*this);
         std::vector<CMerkleTx> vUnused; //!< Used to be vtxPrev
         s << vUnused << mapValueCopy << vOrderForm << fTimeReceivedIsTxTime << nTimeReceived << fFromMe << fSpent;
     }
@@ -441,7 +441,7 @@ public:
         Init(nullptr);
         char fSpent;
 
-        s >> *static_cast<CMerkleTx*>(this);
+        s >> static_cast<CMerkleTx&>(*this);
         std::vector<CMerkleTx> vUnused; //!< Used to be vtxPrev
         s >> vUnused >> mapValue >> vOrderForm >> fTimeReceivedIsTxTime >> nTimeReceived >> fFromMe >> fSpent;
 


### PR DESCRIPTION
This adds a READWRITEAS(type, obj) macro which serializes obj as if it
were casted to (const type&) when const, and to (type&) when non-const.

This makes it usable in serialization code that uses a single
implementation for both serialization and deserializing, which doesn't
know the constness of the object involved.