### PR TITLE
tests/tools: Enable additional Python flake8 rules for automatic linting via Travis

### DIFF
--- a/contrib/devtools/lint-python.sh
+++ b/contrib/devtools/lint-python.sh
@@ -15,6 +15,8 @@
 # E133 closing bracket is missing indentation
 # E223 tab before operator
 # E224 tab after operator
+# E242 tab after ','
+# E266 too many leading '#' for block comment
 # E271 multiple spaces after keyword
 # E272 multiple spaces before keyword
 # E273 tab after keyword
@@ -22,7 +24,10 @@
 # E275 missing whitespace after keyword
 # E304 blank lines found after function decorator
 # E306 expected 1 blank line before a nested definition
+# E401 multiple imports on one line
+# E402 module level import not at top of file
 # E502 the backslash is redundant between brackets
+# E701 multiple statements on one line (colon)
 # E702 multiple statements on one line (semicolon)
 # E703 statement ends with a semicolon
 # E714 test for object identity should be "is not"
@@ -30,6 +35,8 @@
 # E741 do not use variables named "l", "O", or "I"
 # E742 do not define classes named "l", "O", or "I"
 # E743 do not define functions named "l", "O", or "I"
+# E901 SyntaxError: invalid syntax
+# E902 TokenError: EOF in multi-line string
 # F401 module imported but unused
 # F402 import module from line N shadowed by loop variable
 # F404 future import(s) name after other statements
@@ -49,16 +56,19 @@
 # F707 an except: block as not the last exception handler
 # F811 redefinition of unused name from line N
 # F812 list comprehension redefines 'foo' from line N
+# F821 undefined name 'Foo'
 # F822 undefined name name in __all__
 # F823 local variable name … referenced before assignment
 # F831 duplicate argument name in function definition
 # F841 local variable 'foo' is assigned to but never used
 # W292 no newline at end of file
+# W293 blank line contains whitespace
 # W504 line break after binary operator
 # W601 .has_key() is deprecated, use "in"
 # W602 deprecated form of raising exception
 # W603 "<>" is deprecated, use "!="
 # W604 backticks are deprecated, use "repr()"
 # W605 invalid escape sequence "x"
+# W606 'async' and 'await' are reserved keywords starting with Python 3.7
 
-flake8 --ignore=B,C,E,F,I,N,W --select=E112,E113,E115,E116,E125,E131,E133,E223,E224,E271,E272,E273,E274,E275,E304,E306,E502,E702,E703,E714,E721,E741,E742,E743,F401,F402,F404,F406,F407,F601,F602,F621,F622,F631,F701,F702,F703,F704,F705,F706,F707,F811,F812,F822,F823,F831,F841,W292,W504,W601,W602,W603,W604,W605 .
+flake8 --ignore=B,C,E,F,I,N,W --select=E112,E113,E115,E116,E125,E131,E133,E223,E224,E242,E266,E271,E272,E273,E274,E275,E304,E306,E401,E402,E502,E701,E702,E703,E714,E721,E741,E742,E743,F401,E901,E902,F402,F404,F406,F407,F601,F602,F621,F622,F631,F701,F702,F703,F704,F705,F706,F707,F811,F812,F821,F822,F823,F831,F841,W292,W293,W504,W601,W602,W603,W604,W605,W606 .

--- a/contrib/testgen/base58.py
+++ b/contrib/testgen/base58.py
@@ -43,8 +43,10 @@ def b58encode(v):
     # leading 0-bytes in the input become leading-1s
     nPad = 0
     for c in v:
-        if c == 0: nPad += 1
-        else: break
+        if c == 0:
+            nPad += 1
+        else:
+            break
 
     return (__b58chars[0]*nPad) + result
 

--- a/share/rpcauth/rpcauth.py
+++ b/share/rpcauth/rpcauth.py
@@ -25,6 +25,7 @@ salt = "".join([x[2:] for x in hexseq])
 
 #Create 32 byte b64 password
 password = base64.urlsafe_b64encode(os.urandom(32)).decode("utf-8")
+
 m = hmac.new(bytearray(salt, 'utf-8'), bytearray(password, 'utf-8'), "SHA256")
 result = m.hexdigest()
 

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -186,10 +186,10 @@ class RESTTest (BitcoinTestFramework):
         self.test_rest_request("/getutxos/checkmempool", http_method='POST', req_type=ReqType.JSON, status=400, ret_type=RetType.OBJ)
 
         # Test limits
-        long_uri = '/'.join(["{}-{}".format(txid, n) for n in range(20)])
+        long_uri = '/'.join(["{}-{}".format(txid, n_) for n_ in range(20)])
         self.test_rest_request("/getutxos/checkmempool/{}".format(long_uri), http_method='POST', status=400, ret_type=RetType.OBJ)
 
-        long_uri = '/'.join(['{}-{}'.format(txid, n) for n in range(15)])
+        long_uri = '/'.join(['{}-{}'.format(txid, n_) for n_ in range(15)])
         self.test_rest_request("/getutxos/checkmempool/{}".format(long_uri), http_method='POST', status=200)
 
         self.nodes[0].generate(1)  # generate block to not affect upcoming tests


### PR DESCRIPTION
Enabled rules:

```
* E242: tab after ','
* E266: too many leading '#' for block comment
* E401: multiple imports on one line
* E402: module level import not at top of file
* E701: multiple statements on one line (colon)
* E901: SyntaxError: invalid syntax
* E902: TokenError: EOF in multi-line string
* F821: undefined name 'Foo'
* W293: blank line contains whitespace
* W606: 'async' and 'await' are reserved keywords starting with Python 3.7
```

Note to reviewers:
* In general we don't allow whitespace cleanups to existing code, but in order to allow for enabling Travis checking for these rules a few smaller whitespace cleanups had to made as part of this PR.
* Use [this `?w=1` link](https://github.com/bitcoin/bitcoin/pull/12987/files?w=1) to show a diff without whitespace changes.

Before this commit:

```
$ flake8 -qq --statistics --ignore=B,C,E,F,I,N,W --select=E112,E113,E115,E116,E125,E131,E133,E223,E224,E242,E266,E271,E272,E273,E274,E275,E304,E306,E401,E402,E502,E701,E702,E703,E714,E721,E741,E742,E743,F401,E901,E902,F402,F404,F406,F407,F601,F602,F621,F622,F631,F701,F702,F703,F704,F705,F706,F707,F811,F812,F821,F822,F823,F831,F841,W292,W293,W504,W601,W602,W603,W604,W605,W606 .
5 E266 too many leading '#' for block comment
4 E401 multiple imports on one line
6 E402 module level import not at top of file
5 E701 multiple statements on one line (colon)
1 F812 list comprehension redefines 'n' from line 159
4 F821 undefined name 'ConnectionRefusedError'
28 W293 blank line contains whitespace
```

After this commit:

```
$ flake8 -qq --statistics --ignore=B,C,E,F,I,N,W --select=E112,E113,E115,E116,E125,E131,E133,E223,E224,E242,E266,E271,E272,E273,E274,E275,E304,E306,E401,E402,E502,E701,E702,E703,E714,E721,E741,E742,E743,F401,E901,E902,F402,F404,F406,F407,F601,F602,F621,F622,F631,F701,F702,F703,F704,F705,F706,F707,F811,F812,F821,F822,F823,F831,F841,W292,W293,W504,W601,W602,W603,W604,W605,W606 .
$
```
