### PR TITLE
macOS: Prevent Xcode 9.3 build warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -637,11 +637,7 @@ if test x$use_hardening != xno; then
   AX_CHECK_LINK_FLAG([[-Wl,--high-entropy-va]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,--high-entropy-va"])
   AX_CHECK_LINK_FLAG([[-Wl,-z,relro]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-z,relro"])
   AX_CHECK_LINK_FLAG([[-Wl,-z,now]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-z,now"])
-
-  if test x$TARGET_OS != xwindows; then
-    AX_CHECK_COMPILE_FLAG([-fPIE],[PIE_FLAGS="-fPIE"])
-    AX_CHECK_LINK_FLAG([[-pie]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pie"])
-  fi
+  AX_CHECK_LINK_FLAG([[-fPIE -pie]], [PIE_FLAGS="-fPIE"; HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pie"],, [[$CXXFLAG_WERROR]])
 
   case $host in
     *mingw*)


### PR DESCRIPTION
This PR solves #12867 (needs to run autogen.sh && ./configure)

clang (Apple LLVM version 9.1.0 (clang-902.0.39.1)) warns unused
argument '-pie' during compilation.
So we check for warnings in the test using $CXXFLAG_WERROR.

Windows is alse default-pie and was special-cased because it also
warned, but we can also eliminate that case if warnings are caught.