### PR TITLE
Fix inconsistent namespace formatting guidelines

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -50,7 +50,7 @@ Do not submit patches solely to modify the style of existing code.
 [src/.clang-format](/src/.clang-format). You can use the provided
 [clang-format-diff script](/contrib/devtools/README.md#clang-format-diffpy)
 tool to clean up patches automatically before submission.
-  - Braces on new lines for namespaces, classes, functions, methods.
+  - Braces on new lines for classes, functions, methods.
   - Braces on the same line for everything else.
   - 4 space indentation (no tabs) for every block except namespaces.
   - No indentation for `public`/`protected`/`private` or for `namespace`.
@@ -85,8 +85,7 @@ Block style example:
 ```c++
 int g_count = 0;
 
-namespace foo
-{
+namespace foo {
 class Class
 {
     std::string m_name;
@@ -585,11 +584,11 @@ Source code organization
 
 ```c++
 namespace mynamespace {
-    ...
+...
 } // namespace mynamespace
 
 namespace {
-    ...
+...
 } // namespace
 ```
 

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -12,7 +12,10 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
 BinPackParameters: false
 BreakBeforeBinaryOperators: false
-BreakBeforeBraces: Linux
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false
 ColumnLimit:     0


### PR DESCRIPTION
Suggested formatting for namespaces in the developer guide is currently
inconsistent. This commit updates the developer guide and clang-format
configuration to consistently put "namespace" and opening/closing braces
on the same line. Example:

```c++
namespace boost {
namespace signals2 {
class connection;
} // namespace signals2
} // namespace boost
```

Currently the "Source code organization" section has an example like the one
above, but the "Coding style" section example and description put a newline
between the opening "namespace foo" and brace (but oddly no newline between
closing namespace and brace).

Avoiding newlines before namespace opening braces makes nested declarations
less verbose and also avoids asymmetry with closing braces. It's also a
common style used in other codebases:

* https://google.github.io/styleguide/cppguide.html#Namespaces
* https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style#Classes
* https://llvm.org/docs/CodingStandards.html#namespace-indentation