### PR TITLE
Add wallets management functions

### DIFF
--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -261,7 +261,7 @@ class NodeImpl : public Node
     {
 #ifdef ENABLE_WALLET
         std::vector<std::unique_ptr<Wallet>> wallets;
-        for (CWalletRef wallet : ::vpwallets) {
+        for (CWallet* wallet : ::vpwallets) {
             wallets.emplace_back(MakeWallet(*wallet));
         }
         return wallets;

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -261,7 +261,7 @@ class NodeImpl : public Node
     {
 #ifdef ENABLE_WALLET
         std::vector<std::unique_ptr<Wallet>> wallets;
-        for (CWallet* wallet : ::vpwallets) {
+        for (CWallet* wallet : GetWallets()) {
             wallets.emplace_back(MakeWallet(*wallet));
         }
         return wallets;

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -417,7 +417,14 @@ public:
     OutputType getDefaultAddressType() override { return m_wallet.m_default_address_type; }
     OutputType getDefaultChangeType() override { return m_wallet.m_default_change_type; }
 
+    int64_t GetKeysLeftSinceBackup() override { return m_wallet.nKeysLeftSinceAutoBackup; }
+
     int GetPSRounds() override { return privateSendClient.nPrivateSendRounds; }
+
+    bool DoAutoBackup(std::string walletIn, std::string& strBackupWarning, std::string& strBackupError) override
+    {
+        return AutoBackupWallet(GetWallet(walletIn), nullptr, strBackupWarning, strBackupError);
+    }
 
     std::unique_ptr<Handler> handleShowProgress(ShowProgressFn fn) override
     {

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -231,8 +231,14 @@ public:
     //! Get default change type.
     virtual OutputType getDefaultChangeType() = 0;
 
+    //! Get keys left since last backup.
+    virtual int64_t GetKeysLeftSinceBackup() = 0;
+
     //! Return PrivateSend Rounds.
     virtual int GetPSRounds() = 0;
+
+    //! Return result of automatic wallet backup.
+    virtual bool DoAutoBackup(std::string walletIn, std::string& strBackupWarning, std::string& strBackupError) = 0;
 
     //! Register handler for show progress messages.
     using ShowProgressFn = std::function<void(const std::string& title, int progress)>;

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -407,7 +407,7 @@ void OverviewPage::updateAdvancedPSUI(bool _fShowAdvancedPSUI) {
 void OverviewPage::privateSendStatus()
 {
     if(!m_node.MNIsBlockchainsynced() || m_node.shutdownRequested()) return;
-    CWalletRef pwallet = vpwallets.empty() ? nullptr : vpwallets[0];
+    CWallet* pwallet = vpwallets.empty() ? nullptr : vpwallets[0];
     static int64_t nLastDSProgressBlockTime = 0;
 
     int nBestHeight = m_node.getNumBlocks();

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -407,7 +407,6 @@ void OverviewPage::updateAdvancedPSUI(bool _fShowAdvancedPSUI) {
 void OverviewPage::privateSendStatus()
 {
     if(!m_node.MNIsBlockchainsynced() || m_node.shutdownRequested()) return;
-    CWallet* pwallet = vpwallets.empty() ? nullptr : vpwallets[0];
     static int64_t nLastDSProgressBlockTime = 0;
 
     int nBestHeight = m_node.getNumBlocks();
@@ -416,8 +415,8 @@ void OverviewPage::privateSendStatus()
     if(((nBestHeight - privateSendClient.nCachedNumBlocks) / (GetTimeMillis() - nLastDSProgressBlockTime + 1) > 1)) return;
     nLastDSProgressBlockTime = GetTimeMillis();
 
-    QString strKeysLeftText(tr("keys left: %1").arg(pwallet->nKeysLeftSinceAutoBackup));
-    if(pwallet->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_WARNING) {
+    QString strKeysLeftText(tr("keys left: %1").arg(walletModel->wallet().GetKeysLeftSinceBackup()));
+    if(walletModel->wallet().GetKeysLeftSinceBackup() < PRIVATESEND_KEYS_THRESHOLD_WARNING) {
         strKeysLeftText = "<span style='color:red;'>" + strKeysLeftText + "</span>";
     }
     ui->labelPrivateSendEnabled->setToolTip(strKeysLeftText);
@@ -441,7 +440,7 @@ void OverviewPage::privateSendStatus()
 
     // Warn user that wallet is running out of keys
     // NOTE: we do NOT warn user and do NOT create autobackups if mixing is not running
-    if (nWalletBackups > 0 && pwallet->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_WARNING) {
+    if (nWalletBackups > 0 && walletModel->wallet().GetKeysLeftSinceBackup() < PRIVATESEND_KEYS_THRESHOLD_WARNING) {
         QSettings settings;
         if(settings.value("fLowKeysWarning").toBool()) {
             QString strWarn =   tr("Very low number of keys left since last automatic backup!") + "<br><br>" +
@@ -458,7 +457,8 @@ void OverviewPage::privateSendStatus()
 
         std::string strBackupWarning;
         std::string strBackupError;
-        if(!AutoBackupWallet(pwallet, nullptr, strBackupWarning, strBackupError)) {
+        const std::string name = walletModel->getWalletName().toStdString();
+        if(!walletModel->wallet().DoAutoBackup(name, strBackupWarning, strBackupError)) {
             if (!strBackupWarning.empty()) {
                 // It's still more or less safe to continue but warn user anyway
                 LogPrintf("OverviewPage::privateSendStatus -- WARNING! Something went wrong on automatic backup: %s\n", strBackupWarning);

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -180,9 +180,9 @@ void TestGUI()
     TransactionView transactionView(platformStyle.get());
     auto node = interfaces::MakeNode();
     OptionsModel optionsModel(*node);
-    vpwallets.insert(vpwallets.begin(), &wallet);
-    WalletModel walletModel(std::move(node->getWallets()[0]), *node, platformStyle.get(), &optionsModel);
-    vpwallets.erase(vpwallets.begin());
+    AddWallet(&wallet);
+    WalletModel walletModel(std::move(node->getWallets().back()), *node, platformStyle.get(), &optionsModel);
+    RemoveWallet(&wallet);
     sendCoinsDialog.setModel(&walletModel);
     transactionView.setModel(&walletModel);
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -111,7 +111,7 @@ UniValue validateaddress(const JSONRPCRequest& request)
     {
 
 #ifdef ENABLE_WALLET
-        if (!::vpwallets.empty() && IsDeprecatedRPCEnabled("validateaddress")) {
+        if (!GetWallets().empty() && IsDeprecatedRPCEnabled("validateaddress")) {
             ret.pushKVs(getaddressinfo(request));
         }
 #endif

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -111,7 +111,7 @@ UniValue validateaddress(const JSONRPCRequest& request)
     {
 
 #ifdef ENABLE_WALLET
-        if (!GetWallets().empty() && IsDeprecatedRPCEnabled("validateaddress")) {
+        if (HasWallets() && IsDeprecatedRPCEnabled("validateaddress")) {
             ret.pushKVs(getaddressinfo(request));
         }
 #endif

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -374,7 +374,7 @@ void WalletInit::Start(CScheduler& scheduler, CConnman* connman) const
     for (CWallet* pwallet : GetWallets()) {
         pwallet->postInitProcess(scheduler, gArgs.GetBoolArg("-mnconflock", true) ? true : false);
     }
-    if(!GetWallets().empty()) privateSendClient.Controller(scheduler, connman);
+    if(HasWallets()) privateSendClient.Controller(scheduler, connman);
 }
 
 void WalletInit::Flush() const

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -371,7 +371,7 @@ bool WalletInit::Open() const
 
 void WalletInit::Start(CScheduler& scheduler, CConnman* connman) const
 {
-    for (CWalletRef pwallet : vpwallets) {
+    for (CWallet* pwallet : vpwallets) {
         pwallet->postInitProcess(scheduler, gArgs.GetBoolArg("-mnconflock", true) ? true : false);
     }
     if (privateSendClient.getWallet(vpwallets[0]->GetName())) {
@@ -381,14 +381,14 @@ void WalletInit::Start(CScheduler& scheduler, CConnman* connman) const
 
 void WalletInit::Flush() const
 {
-    for (CWalletRef pwallet : vpwallets) {
+    for (CWallet* pwallet : vpwallets) {
         pwallet->Flush(false);
     }
 }
 
 void WalletInit::Stop() const
 {
-    for (CWalletRef pwallet : vpwallets) {
+    for (CWallet* pwallet : vpwallets) {
         pwallet->Flush(true);
     }
     // Stop PrivateSend, release keys
@@ -398,7 +398,7 @@ void WalletInit::Stop() const
 
 void WalletInit::Close() const
 {
-    for (CWalletRef pwallet : vpwallets) {
+    for (CWallet* pwallet : vpwallets) {
         delete pwallet;
     }
     vpwallets.clear();
@@ -418,7 +418,7 @@ WalletInterface* const g_wallet_interface = &g_wallet;
 bool CWalletInterface::CheckMNCollateral(COutPoint& outpointRet, CTxDestination &destRet, CPubKey& pubKeyRet, CKey& keyRet, const std::string& strTxHash, const std::string& strOutputIndex)
 {
     bool foundmnout = false;
-    for (CWalletRef pwallet : vpwallets) {
+    for (CWallet* pwallet : vpwallets) {
         if (pwallet->GetMasternodeOutpointAndKeys(outpointRet, destRet, pubKeyRet, keyRet, strTxHash, strOutputIndex))
             foundmnout = true;
     }

--- a/src/wallet/privatesend-client.cpp
+++ b/src/wallet/privatesend-client.cpp
@@ -25,7 +25,7 @@ CPrivateSendClient privateSendClient;
 
 bool CPrivateSendClient::getWallet(const std::string walletIn)
 {
-    pmixingwallet = GetWalletForPSRequest(walletIn);
+    pmixingwallet = GetWallet(walletIn);
     if (!pmixingwallet)
         return false;
     else

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -51,7 +51,7 @@ CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
     if (request.URI.substr(0, WALLET_ENDPOINT_BASE.size()) == WALLET_ENDPOINT_BASE) {
         // wallet endpoint was used
         std::string requestedWallet = urlDecode(request.URI.substr(WALLET_ENDPOINT_BASE.size()));
-        for (CWalletRef pwallet : ::vpwallets) {
+        for (CWallet* pwallet : ::vpwallets) {
             if (pwallet->GetName() == requestedWallet) {
                 return pwallet;
             }
@@ -2934,7 +2934,7 @@ UniValue listwallets(const JSONRPCRequest& request)
 
     UniValue obj(UniValue::VARR);
 
-    for (CWalletRef pwallet : vpwallets) {
+    for (CWallet* pwallet : vpwallets) {
 
         if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
             return NullUniValue;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -71,7 +71,7 @@ bool EnsureWalletIsAvailable(CWallet * const pwallet, bool avoidException)
 {
     if (pwallet) return true;
     if (avoidException) return false;
-    if (GetWallets().empty()) {
+    if (!HasWallets()) {
         // Note: It isn't currently possible to trigger this error because
         // wallet RPC methods aren't registered unless a wallet is loaded. But
         // this error is being kept as a precaution, because it's possible in

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -51,14 +51,13 @@ CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
     if (request.URI.substr(0, WALLET_ENDPOINT_BASE.size()) == WALLET_ENDPOINT_BASE) {
         // wallet endpoint was used
         std::string requestedWallet = urlDecode(request.URI.substr(WALLET_ENDPOINT_BASE.size()));
-        for (CWallet* pwallet : ::vpwallets) {
-            if (pwallet->GetName() == requestedWallet) {
-                return pwallet;
-            }
-        }
-        throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Requested wallet does not exist or is not loaded");
+        CWallet* pwallet = GetWallet(requestedWallet);
+        if (!pwallet) throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Requested wallet does not exist or is not loaded");
+        return pwallet;
     }
-    return ::vpwallets.size() == 1 || (request.fHelp && ::vpwallets.size() > 0) ? ::vpwallets[0] : nullptr;
+
+    std::vector<CWallet*> wallets = GetWallets();
+    return wallets.size() == 1 || (request.fHelp && wallets.size() > 0) ? wallets[0] : nullptr;
 }
 
 std::string HelpRequiringPassphrase(CWallet * const pwallet)
@@ -72,7 +71,7 @@ bool EnsureWalletIsAvailable(CWallet * const pwallet, bool avoidException)
 {
     if (pwallet) return true;
     if (avoidException) return false;
-    if (::vpwallets.empty()) {
+    if (GetWallets().empty()) {
         // Note: It isn't currently possible to trigger this error because
         // wallet RPC methods aren't registered unless a wallet is loaded. But
         // this error is being kept as a precaution, because it's possible in
@@ -2934,8 +2933,7 @@ UniValue listwallets(const JSONRPCRequest& request)
 
     UniValue obj(UniValue::VARR);
 
-    for (CWallet* pwallet : vpwallets) {
-
+    for (CWallet* pwallet : GetWallets()) {
         if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
             return NullUniValue;
         }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -411,7 +411,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
     // after.
     {
         CWallet wallet("dummy", WalletDatabase::CreateDummy());
-        vpwallets.insert(vpwallets.begin(), &wallet);
+        AddWallet(&wallet);
         UniValue keys;
         keys.setArray();
         UniValue key;
@@ -442,7 +442,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
                       "downloading and rescanning the relevant blocks (see -reindex and -rescan "
                       "options).\"}},{\"success\":true}]",
                               0, oldTip->GetBlockTimeMax(), TIMESTAMP_WINDOW));
-        vpwallets.erase(vpwallets.begin());
+        RemoveWallet(&wallet);
     }
 }
 
@@ -477,9 +477,9 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         JSONRPCRequest request;
         request.params.setArray();
         request.params.push_back((pathTemp / "wallet.backup").string());
-        vpwallets.insert(vpwallets.begin(), &wallet);
+        AddWallet(&wallet);
         ::dumpwallet(request);
-        vpwallets.erase(vpwallets.begin());
+        RemoveWallet(&wallet);
     }
 
     // Call importwallet RPC and verify all blocks with timestamps >= BLOCK_TIME
@@ -490,9 +490,9 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         JSONRPCRequest request;
         request.params.setArray();
         request.params.push_back((pathTemp / "wallet.backup").string());
-        vpwallets.insert(vpwallets.begin(), &wallet);
+        AddWallet(&wallet);
         ::importwallet(request);
-        vpwallets.erase(vpwallets.begin());
+        RemoveWallet(&wallet);
 
         LOCK(wallet.cs_wallet);
         BOOST_CHECK_EQUAL(wallet.mapWallet.size(), 3U);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -35,12 +35,45 @@
 #include <governance.h>
 #include <wallet/privatesend-client.h>
 
+#include <algorithm>
 #include <assert.h>
 #include <future>
 
 #include <boost/algorithm/string/replace.hpp>
 
-std::vector<CWallet*> vpwallets;
+static std::vector<CWallet*> vpwallets;
+
+bool AddWallet(CWallet* wallet)
+{
+    assert(wallet);
+    std::vector<CWallet*>::const_iterator i = std::find(vpwallets.begin(), vpwallets.end(), wallet);
+    if (i != vpwallets.end()) return false;
+    vpwallets.push_back(wallet);
+    return true;
+}
+
+bool RemoveWallet(CWallet* wallet)
+{
+    assert(wallet);
+    std::vector<CWallet*>::iterator i = std::find(vpwallets.begin(), vpwallets.end(), wallet);
+    if (i == vpwallets.end()) return false;
+    vpwallets.erase(i);
+    return true;
+}
+
+std::vector<CWallet*> GetWallets()
+{
+    return vpwallets;
+}
+
+CWallet* GetWallet(const std::string& name)
+{
+    for (CWallet* wallet : vpwallets) {
+        if (wallet->GetName() == name) return wallet;
+    }
+    return nullptr;
+}
+
 /** Transaction fee set by the user */
 CFeeRate payTxFee(DEFAULT_TRANSACTION_FEE);
 unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -40,7 +40,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 
-std::vector<CWalletRef> vpwallets;
+std::vector<CWallet*> vpwallets;
 /** Transaction fee set by the user */
 CFeeRate payTxFee(DEFAULT_TRANSACTION_FEE);
 unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -61,6 +61,11 @@ bool RemoveWallet(CWallet* wallet)
     return true;
 }
 
+bool HasWallets()
+{
+    return !vpwallets.empty();
+}
+
 std::vector<CWallet*> GetWallets()
 {
     return vpwallets;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -34,8 +34,7 @@
 #include <utility>
 #include <vector>
 
-typedef CWallet* CWalletRef;
-extern std::vector<CWalletRef> vpwallets;
+extern std::vector<CWallet*> vpwallets;
 
 /**
  * Settings
@@ -1337,10 +1336,10 @@ std::vector<CTxDestination> GetAllDestinationsForKey(const CPubKey& key);
 class WalletRescanReserver
 {
 private:
-    CWalletRef m_wallet;
+    CWallet* m_wallet;
     bool m_could_reserve;
 public:
-    explicit WalletRescanReserver(CWalletRef w) : m_wallet(w), m_could_reserve(false) {}
+    explicit WalletRescanReserver(CWallet* w) : m_wallet(w), m_could_reserve(false) {}
 
     bool reserve()
     {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -34,7 +34,10 @@
 #include <utility>
 #include <vector>
 
-extern std::vector<CWallet*> vpwallets;
+bool AddWallet(CWallet* wallet);
+bool RemoveWallet(CWallet* wallet);
+std::vector<CWallet*> GetWallets();
+CWallet* GetWallet(const std::string& name);
 
 /**
  * Settings
@@ -289,7 +292,7 @@ public:
 //Get the marginal bytes of spending the specified output
 int CalculateMaximumSignedInputSize(const CTxOut& txout, const CWallet* pwallet);
 
-/** 
+/**
  * A transaction with a bunch of additional info that only the owner cares about.
  * It includes any unrecorded transactions needed to link it back to the block chain.
  */
@@ -695,7 +698,7 @@ struct CoinEligibilityFilter
 };
 
 class WalletRescanReserver; //forward declarations for ScanForWalletTransactions/RescanFromTime
-/** 
+/**
  * A CWallet is an extension of a keystore, which also maintains a set of transactions and balances,
  * and provides the ability to create new transactions.
  */
@@ -996,7 +999,7 @@ public:
     void GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) const;
     unsigned int ComputeTimeSmart(const CWalletTx& wtx) const;
 
-    /** 
+    /**
      * Increment the next transaction order id
      * @return next transaction order id
      */
@@ -1138,7 +1141,7 @@ public:
     }
 
     void GetScriptForMining(std::shared_ptr<CReserveScript> &script);
-    
+
     unsigned int GetKeyPoolSize()
     {
         AssertLockHeld(cs_wallet); // set{Ex,In}ternalKeyPool
@@ -1163,7 +1166,7 @@ public:
     //! Flush wallet (bitdb flush)
     void Flush(bool shutdown=false);
 
-    /** 
+    /**
      * Address book entry changed.
      * @note called with lock cs_wallet held.
      */
@@ -1172,7 +1175,7 @@ public:
             const std::string &purpose,
             ChangeType status)> NotifyAddressBookChanged;
 
-    /** 
+    /**
      * Wallet transaction added, removed or updated.
      * @note called with lock cs_wallet held.
      */
@@ -1219,7 +1222,7 @@ public:
 
     /* Generates a new HD master key (will not be activated) */
     CPubKey GenerateNewHDMasterKey();
-    
+
     /* Set the current HD master key (will reset the chain child index counters)
        Sets the master key's version based on the current wallet version (so the
        caller must ensure the current wallet version is correct before calling
@@ -1290,7 +1293,7 @@ public:
 };
 
 
-/** 
+/**
  * DEPRECATED Account information.
  * Stored in wallet with key "acc"+string account name.
  */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -36,6 +36,7 @@
 
 bool AddWallet(CWallet* wallet);
 bool RemoveWallet(CWallet* wallet);
+bool HasWallets();
 std::vector<CWallet*> GetWallets();
 CWallet* GetWallet(const std::string& name);
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -760,7 +760,7 @@ void MaybeCompactWalletDB()
         return;
     }
 
-    for (CWallet* pwallet : vpwallets) {
+    for (CWallet* pwallet : GetWallets()) {
         WalletDatabase& dbh = pwallet->GetDBHandle();
 
         unsigned int nUpdateCounter = dbh.nUpdateCounter;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -760,7 +760,7 @@ void MaybeCompactWalletDB()
         return;
     }
 
-    for (CWalletRef pwallet : vpwallets) {
+    for (CWallet* pwallet : vpwallets) {
         WalletDatabase& dbh = pwallet->GetDBHandle();
 
         unsigned int nUpdateCounter = dbh.nUpdateCounter;

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -29,7 +29,7 @@ fs::path GetWalletDir()
 
 CWallet *GetWalletForPSRequest(std::string requestedWallet)
 {
-    for (CWalletRef pwallet : ::vpwallets) {
+    for (CWallet* pwallet : ::vpwallets) {
         if (pwallet->GetName() == requestedWallet) {
             return pwallet;
         }

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -27,16 +27,6 @@ fs::path GetWalletDir()
     return path;
 }
 
-CWallet *GetWalletForPSRequest(std::string requestedWallet)
-{
-    for (CWallet* pwallet : ::vpwallets) {
-        if (pwallet->GetName() == requestedWallet) {
-            return pwallet;
-        }
-    }
-    return ::vpwallets.size() == 1 ? ::vpwallets[0] : nullptr;
-}
-
 CKeyHolder::CKeyHolder(CWallet* pwallet) :
     reserveKey(pwallet)
 {

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -18,7 +18,6 @@ fs::path GetWalletDir();
  * @param[in]
  * @return nullptr if no wallet should be used, or a pointer to the CWallet
  */
-CWallet *GetWalletForPSRequest(std::string requestedWallet);
 
 class CKeyHolder
 {


### PR DESCRIPTION
This is a small step towards dynamic wallet load/unload. The wallets *registry* `vpwallets` is used in several places. With these new functions all `vpwallets` usage are removed and `vpwallets` is now a static variable (no external linkage).

The typedef `CWalletRef` is also removed as it is narrowly used.

More interface implementations for the GUI (module specific functionality)