### PR TITLE
 qt: Initialize non-static class members that were previously neither initialized where defined nor in constructor

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -160,7 +160,7 @@ public:
 };
 
 AddressTableModel::AddressTableModel(WalletModel *parent) :
-    QAbstractTableModel(parent),walletModel(parent),priv(0)
+    QAbstractTableModel(parent), walletModel(parent)
 {
     columns << tr("Label") << tr("Address");
     priv = new AddressTablePriv(this);

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -86,7 +86,7 @@ private:
     WalletModel *walletModel;
     AddressTablePriv *priv;
     QStringList columns;
-    EditStatus editStatus;
+    EditStatus editStatus = OK;
 
     /** Look up address book data given an address string. */
     bool getAddressData(const QString &address, std::string* name, std::string* purpose) const;

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -83,8 +83,8 @@ public:
     OutputType GetDefaultAddressType() const;
 
 private:
-    WalletModel *walletModel;
-    AddressTablePriv *priv;
+    WalletModel *walletModel = nullptr;
+    AddressTablePriv *priv = nullptr;
     QStringList columns;
     EditStatus editStatus = OK;
 

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -83,7 +83,7 @@ public:
     OutputType GetDefaultAddressType() const;
 
 private:
-    WalletModel *walletModel = nullptr;
+    WalletModel* const walletModel;
     AddressTablePriv *priv = nullptr;
     QStringList columns;
     EditStatus editStatus = OK;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -456,12 +456,7 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
     QWidget(parent),
     m_node(node),
     ui(new Ui::RPCConsole),
-    clientModel(0),
-    historyPtr(0),
-    platformStyle(_platformStyle),
-    peersTableContextMenu(0),
-    banTableContextMenu(0),
-    consoleFontSize(0)
+    platformStyle(_platformStyle)
 {
     ui->setupUi(this);
     QString theme = GUIUtil::getThemeName();

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -159,7 +159,7 @@ private:
     QMenu *peersTableContextMenu;
     QMenu *banTableContextMenu;
     int consoleFontSize;
-    QCompleter *autoCompleter;
+    QCompleter *autoCompleter = nullptr;
     QThread thread;
     QString m_last_wallet_id;
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -148,13 +148,13 @@ private:
     };
 
     interfaces::Node& m_node;
-    Ui::RPCConsole *ui = nullptr;
+    Ui::RPCConsole* const ui;
     ClientModel *clientModel = nullptr;
     QStringList history;
     int historyPtr = 0;
     QString cmdBeforeBrowsing;
     QList<NodeId> cachedNodeids;
-    const PlatformStyle *platformStyle = nullptr;
+    const PlatformStyle* const platformStyle;
     RPCTimerInterface *rpcTimerInterface = nullptr;
     QMenu *peersTableContextMenu = nullptr;
     QMenu *banTableContextMenu = nullptr;

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -148,17 +148,17 @@ private:
     };
 
     interfaces::Node& m_node;
-    Ui::RPCConsole *ui;
-    ClientModel *clientModel;
+    Ui::RPCConsole *ui = nullptr;
+    ClientModel *clientModel = nullptr;
     QStringList history;
-    int historyPtr;
+    int historyPtr = 0;
     QString cmdBeforeBrowsing;
     QList<NodeId> cachedNodeids;
-    const PlatformStyle *platformStyle;
-    RPCTimerInterface *rpcTimerInterface;
-    QMenu *peersTableContextMenu;
-    QMenu *banTableContextMenu;
-    int consoleFontSize;
+    const PlatformStyle *platformStyle = nullptr;
+    RPCTimerInterface *rpcTimerInterface = nullptr;
+    QMenu *peersTableContextMenu = nullptr;
+    QMenu *banTableContextMenu = nullptr;
+    int consoleFontSize = 0;
     QCompleter *autoCompleter = nullptr;
     QThread thread;
     QString m_last_wallet_id;


### PR DESCRIPTION
Initialize variables previously neither defined where defined nor in constructor:
* `editStatus`
* `autoCompleter`

Also; initialize non-static class members where they are defined in accordance with developer notes.
