### PR TITLE
Bugfix: the end of a reorged chain is invalid when connect fails

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2559,8 +2559,9 @@ bool CChainState::ActivateBestChainStep(CValidationState& state, const CChainPar
             if (!ConnectTip(state, chainparams, pindexConnect, pindexConnect == pindexMostWork ? pblock : std::shared_ptr<const CBlock>(), connectTrace, disconnectpool)) {
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.
-                    if (!state.CorruptionPossible())
-                        InvalidChainFound(vpindexToConnect.back());
+                    if (!state.CorruptionPossible()) {
+                        InvalidChainFound(vpindexToConnect.front());
+                    }
                     state = CValidationState();
                     fInvalidFound = true;
                     fContinue = false;


### PR DESCRIPTION
Introduced in 4e0eed88acdd41826868c151373068bfad18b84d

When an invalid block is found during a reorg, we know the last of the blocks in
the was-to-be-connected chain is invalid, but not necessarily the first. As
vpIndexToConnect is ordered in decreasing height, the end of the reorg is the
front of the vector, and not the back.

This only affected the warning system.