### PR TITLE
Fix Clang Static Analyzer warnings

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -560,6 +560,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
         // Need to update only after we know CreateNewBlock succeeded
         pindexPrev = pindexPrevNew;
     }
+    assert(pindexPrev);
     CBlock* pblock = &pblocktemplate->block; // pointer for convenience
     const Consensus::Params& consensusParams = Params().GetConsensus();
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1065,6 +1065,7 @@ static void TestOtherProcess(fs::path dirname, std::string lockname, int fd)
             ReleaseDirectoryLocks();
             ch = true; // Always succeeds
             rv = write(fd, &ch, 1);
+            assert(rv == 1);
             break;
         case ExitCommand:
             close(fd);

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -536,19 +536,9 @@ BOOST_AUTO_TEST_CASE(SelectCoins_test)
     std::exponential_distribution<double> distribution (100);
     FastRandomContext rand;
 
-    // Output stuff
-    CAmount out_value = 0;
-    CoinSet out_set;
-    CAmount target = 0;
-    bool bnb_used;
-
     // Run this test 100 times
     for (int i = 0; i < 100; ++i)
     {
-        // Reset
-        out_value = 0;
-        target = 0;
-        out_set.clear();
         empty_wallet();
 
         // Make a wallet with 1000 exponentially distributed random inputs
@@ -561,11 +551,14 @@ BOOST_AUTO_TEST_CASE(SelectCoins_test)
         CFeeRate rate(rand.randrange(300) + 100);
 
         // Generate a random target value between 1000 and wallet balance
-        target = rand.randrange(balance - 1000) + 1000;
+        CAmount target = rand.randrange(balance - 1000) + 1000;
 
         // Perform selection
         CoinSelectionParams coin_selection_params_knapsack(false, 34, 148, CFeeRate(0), 0);
         CoinSelectionParams coin_selection_params_bnb(true, 34, 148, CFeeRate(0), 0);
+        CoinSet out_set;
+        CAmount out_value = 0;
+        bool bnb_used = false;
         BOOST_CHECK(testWallet.SelectCoinsMinConf(target, filter_standard, vCoins, out_set, out_value, coin_selection_params_bnb, bnb_used) ||
                     testWallet.SelectCoinsMinConf(target, filter_standard, vCoins, out_set, out_value, coin_selection_params_knapsack, bnb_used));
         BOOST_CHECK_GE(out_value, target);


### PR DESCRIPTION
Fix Clang Static Analyzer warnings reported by @kallewoof in #12961:

* Fix dead stores. Values were stored but never read.
* Add assertion to guide static analyzers. See #12961 for details.