### PR TITLE
Break circular dependency: chain -> pow -> chain

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -7,8 +7,8 @@
 #define BITCOIN_CHAIN_H
 
 #include <arith_uint256.h>
+#include <consensus/params.h>
 #include <primitives/block.h>
-#include <pow.h>
 #include <tinyformat.h>
 #include <uint256.h>
 

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -5,6 +5,7 @@
 #include <blockencodings.h>
 #include <consensus/merkle.h>
 #include <chainparams.h>
+#include <pow.h>
 #include <random.h>
 
 #include <test/test_chaincoin.h>

--- a/src/test/test_chaincoin.cpp
+++ b/src/test/test_chaincoin.cpp
@@ -11,6 +11,7 @@
 #include <validation.h>
 #include <miner.h>
 #include <net_processing.h>
+#include <pow.h>
 #include <ui_interface.h>
 #include <streams.h>
 #include <rpc/server.h>


### PR DESCRIPTION
chain.h does not actually depend on the methods defined in pow.h, just its
include of consensus/params.h, which is standalone and can be included instead.

Confirmed by inspection and successful build.