### PR TITLE
Revert "Merge #12870: make clean removes src/qt/moc_ files"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -294,5 +294,6 @@ clean-docs:
 	rm -rf doc/doxygen
 
 clean-local: clean-docs
-	rm -rf coverage_percent.txt test_chaincoin.coverage/ total.coverage/ test/tmp/ cache/ $(OSX_APP) src/qt/moc_*
+	rm -rf coverage_percent.txt test_chaincoin.coverage/ total.coverage/ test/tmp/ cache/ $(OSX_APP)
 	rm -rf test/functional/__pycache__ test/functional/test_framework/__pycache__ test/cache
+


### PR DESCRIPTION
As noted by theuni and Sjors in #12870, qt moc cleaning is handled
by CLEAN_QT via QT_MOC_CPP in Makefile.qt.include.

In my testing I configured, built and cleaned with qt4 and qt5 both,
absent the associated wildcard, and no MOC files were left after clean.
Propose we revert the change and reconsider if a specific file
is identified, then add that file to QT_MOC_CPP.

This reverts commit 1d540046fe47eb7b6062c55ebebd801ece96231c, reversing
changes made to ad960f5771dc251c8e1198dd8a82e18df4562171.