### PR TITLE
trivial: Mark overrides as such.

### DIFF
--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -111,9 +111,9 @@ public:
 class ConsolePrinter : public Printer
 {
 public:
-    void header();
-    void result(const State& state);
-    void footer();
+    void header() override;
+    void result(const State& state) override;
+    void footer() override;
 };
 
 // creates box plot with plotly.js
@@ -121,9 +121,9 @@ class PlotlyPrinter : public Printer
 {
 public:
     PlotlyPrinter(std::string plotly_url, int64_t width, int64_t height);
-    void header();
-    void result(const State& state);
-    void footer();
+    void header() override;
+    void result(const State& state) override;
+    void footer() override;
 
 private:
     std::string m_plotly_url;

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -25,12 +25,12 @@ struct TestSubscriber : public CValidationInterface {
 
     TestSubscriber(uint256 tip) : m_expected_tip(tip) {}
 
-    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
+    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override
     {
         BOOST_CHECK_EQUAL(m_expected_tip, pindexNew->GetBlockHash());
     }
 
-    void BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex, const std::vector<CTransactionRef>& txnConflicted)
+    void BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex, const std::vector<CTransactionRef>& txnConflicted) override
     {
         BOOST_CHECK_EQUAL(m_expected_tip, block->hashPrevBlock);
         BOOST_CHECK_EQUAL(m_expected_tip, pindex->pprev->GetBlockHash());
@@ -38,7 +38,7 @@ struct TestSubscriber : public CValidationInterface {
         m_expected_tip = block->GetHash();
     }
 
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& block)
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& block) override
     {
         BOOST_CHECK_EQUAL(m_expected_tip, block->GetHash());
 


### PR DESCRIPTION
This trivial change adds the "override" keyword to some methods of
subclasses meant to override interface methods.  This ensures that any
future change to the interface' method signatures which are not correctly
mirrored in the subclass will break at compile time with a clear error message,
rather than fail at runtime (which is harder to debug).