### PR TITLE
Declare TorReply parsing functions in torcontrol_tests

### DIFF
--- a/src/test/torcontrol_tests.cpp
+++ b/src/test/torcontrol_tests.cpp
@@ -3,9 +3,17 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
 #include <test/test_chaincoin.h>
-#include <torcontrol.cpp>
+#include <torcontrol.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <map>
+#include <string>
+#include <utility>
+
+
+std::pair<std::string, std::string> SplitTorReplyLine(const std::string& s);
+std::map<std::string, std::string> ParseTorReplyMapping(const std::string& s);
 
 
 BOOST_FIXTURE_TEST_SUITE(torcontrol_tests, BasicTestingSetup)

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -253,7 +253,7 @@ bool TorControlConnection::Command(const std::string &cmd, const ReplyHandlerCB&
  * Grammar is implicitly defined in https://spec.torproject.org/control-spec by
  * the server reply formats for PROTOCOLINFO (S3.21) and AUTHCHALLENGE (S3.24).
  */
-static std::pair<std::string,std::string> SplitTorReplyLine(const std::string &s)
+std::pair<std::string,std::string> SplitTorReplyLine(const std::string &s)
 {
     size_t ptr=0;
     std::string type;
@@ -272,7 +272,7 @@ static std::pair<std::string,std::string> SplitTorReplyLine(const std::string &s
  * the server reply formats for PROTOCOLINFO (S3.21), AUTHCHALLENGE (S3.24),
  * and ADD_ONION (S3.27). See also sections 2.1 and 2.3.
  */
-static std::map<std::string,std::string> ParseTorReplyMapping(const std::string &s)
+std::map<std::string,std::string> ParseTorReplyMapping(const std::string &s)
 {
     std::map<std::string,std::string> mapping;
     size_t ptr=0;
@@ -775,4 +775,3 @@ void StopTorControl()
         gBase = nullptr;
     }
 }
-


### PR DESCRIPTION
Rather than including the implementation file into the test,
which is bad practice.