### PR TITLE
Ensure gitian-build.sh uses bash

### DIFF
--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright (c) 2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.


### PR DESCRIPTION
If the user has some other login shell (e.g., ksh), the bashisms in gitian-build.sh don't work so well.