### PR TITLE
bench: Don't return a bool from main

### DIFF
--- a/src/bench/bench_chaincoin.cpp
+++ b/src/bench/bench_chaincoin.cpp
@@ -39,20 +39,19 @@ static void SetupBenchArgs()
     gArgs.AddArg("-help", "", false, OptionsCategory::HIDDEN);
 }
 
-int
-main(int argc, char** argv)
+int main(int argc, char** argv)
 {
     SetupBenchArgs();
     std::string error;
     if (!gArgs.ParseParameters(argc, argv, error)) {
         fprintf(stderr, "Error parsing command line arguments: %s\n", error.c_str());
-        return false;
+        return EXIT_FAILURE;
     }
 
     if (HelpRequested(gArgs)) {
         std::cout << gArgs.GetHelpMessage();
 
-        return 0;
+        return EXIT_SUCCESS;
     }
 
     SHA256AutoDetect();
@@ -80,4 +79,6 @@ main(int argc, char** argv)
     benchmark::BenchRunner::RunAll(*printer, evaluations, scaling_factor, regex_filter, is_list_only);
 
     ECC_Stop();
+
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Return `EXIT_SUCCESS` from `main()` on error, not the bool `false`
(introduced in #13112). This is the correct value to return on error,
and also shuts up a clang warning.

Also add a final return for clarity.