### PR TITLE
qa: Avoid checking reject code for now

### DIFF
--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -21,8 +21,6 @@ from test_framework.util import (
 )
 
 
-REJECT_INVALID = 16
-
 class InvalidTxRequestTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
@@ -73,7 +71,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         # and we get disconnected immediately
         self.log.info('Test a transaction that is rejected')
         tx1 = create_transaction(block1.vtx[0], 0, b'\x64' * 35, 50 * COIN - 12000)
-        node.p2p.send_txs_and_test([tx1], node, success=False, expect_disconnect=True, reject_code=REJECT_INVALID, reject_reason=b'mandatory-script-verify-flag-failed (Invalid OP_IF construction)')
+        node.p2p.send_txs_and_test([tx1], node, success=False, expect_disconnect=True)
 
         # Make two p2p connections to provide the node with orphans
         # * p2ps[0] will send valid orphan txs (one with low fee)


### PR DESCRIPTION
The node will often disconnect before sending a reject code. A more
robust solution would be to read from the debug log.