### PR TITLE
doc: split FreeBSD build instructions out of build-unix.md

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -1,0 +1,46 @@
+FreeBSD build guide
+======================
+(updated for FreeBSD 11.1)
+
+This guide describes how to build bitcoind and command-line utilities on FreeBSD.
+
+This guide does not contain instructions for building the GUI.
+
+## Preparation
+
+You will need the following dependencies, which can be installed as root via pkg:
+
+```
+pkg install autoconf automake boost-libs git gmake libevent libtool openssl pkgconf
+```
+
+For the wallet (optional):
+```
+./contrib/install_db4.sh `pwd`
+export BDB_PREFIX='$PWD/db4'
+```
+
+See [dependencies.md](dependencies.md) for a complete overview.
+
+Download the source code:
+```
+git clone https://github.com/bitcoin/bitcoin
+```
+
+## Building Bitcoin Core
+
+**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
+
+```
+./autogen.sh
+
+./configure                  # to build with wallet OR
+./configure --disable-wallet # to build without wallet
+
+gmake
+```
+
+*Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
+It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and
+use the versioned gdb command (e.g. `gdb7111`).
+

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -2,8 +2,7 @@ UNIX BUILD NOTES
 ====================
 Some notes on how to build Chaincoin Core in Unix.
 
-(For BSD specific instructions, see [build-openbsd.md](build-openbsd.md) and/or
-[build-netbsd.md](build-netbsd.md))
+(For BSD specific instructions, see `build-*bsd.md` in this directory.)
 
 Note
 ---------------------
@@ -303,33 +302,3 @@ To build executables for ARM:
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
 
-Building on FreeBSD
---------------------
-
-(Updated as of FreeBSD 11.0)
-
-Clang is installed by default as `cc` compiler, this makes it easier to get
-started than on [OpenBSD](build-openbsd.md). Installing dependencies:
-
-    pkg install autoconf automake libtool pkgconf
-    pkg install boost-libs openssl libevent
-    pkg install gmake
-
-You need to use GNU make (`gmake`) instead of `make`.
-(`libressl` instead of `openssl` will also work)
-
-For the wallet (optional):
-
-    ./contrib/install_db4.sh `pwd`
-    setenv BDB_PREFIX $PWD/db4
-
-Then build using:
-
-    ./autogen.sh
-    ./configure --disable-wallet # OR
-    ./configure BDB_CFLAGS="-I${BDB_PREFIX}/include" BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx"
-    gmake
-
-*Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
-It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and
-use the versioned gdb command e.g. `gdb7111`.


### PR DESCRIPTION
docs: Linked to the 'Building on FreeBSD' section of the Unix guide where it lists BSD specific guides.

Created a FreeBSD build guide (doc/build-freebsd.md).

Added in warning about the version of 'gdb' installed by default.

Removed the FreeBSD build instructions now that they have their own guide (doc/build-freebsd.md).

Updated the sentence to refer to the BSD guides in the 'doc' directory for more specific BSD build instructions.

Minor grammatical fix.