### PR TITLE
lint: Add linter to error on #include <*.cpp>

### DIFF
--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -33,6 +33,14 @@ for CPP_FILE in $(filter_suffix cpp); do
     fi
 done
 
+INCLUDED_CPP_FILES=$(git grep -E "^#include [<\"][^>\"]+\.cpp[>\"]" -- "*.cpp" "*.h")
+if [[ ${INCLUDED_CPP_FILES} != "" ]]; then
+    echo "The following files #include .cpp files:"
+    echo "${INCLUDED_CPP_FILES}"
+    echo
+    EXIT_CODE=1
+fi
+
 EXPECTED_BOOST_INCLUDES=(
     boost/algorithm/string.hpp
     boost/algorithm/string/case_conv.hpp


### PR DESCRIPTION
Files should depend on one another by interface, not by implementation.
This checks for quoted includes as well.

With practicalswift