### PR TITLE
[wallet] [rpc] Remove getlabeladdress RPC

### DIFF
--- a/doc/release-notes-pr12892.md
+++ b/doc/release-notes-pr12892.md
@@ -18,7 +18,7 @@ Here are the changes to RPC methods:
 | Deprecated Method       | New Method            | Notes       |
 | :---------------------- | :-------------------- | :-----------|
 | `getaccount`            | `getaddressinfo`      | `getaddressinfo` returns a json object with address information instead of just the name of the account as a string. |
-| `getaccountaddress`     | `getlabeladdress`     | `getlabeladdress` throws an error by default if the label does not already exist, but provides a `force` option for compatibility with existing applications. |
+| `getaccountaddress`     | n/a                   | There is no replacement for `getaccountaddress` since labels do not have an associated receive address. |
 | `getaddressesbyaccount` | `getaddressesbylabel` | `getaddressesbylabel` returns a json object with the addresses as keys, instead of a list of strings. |
 | `getreceivedbyaccount`  | `getreceivedbylabel`  | _no change in behavior_ |
 | `listaccounts`          | `listlabels`          | `listlabels` does not return a balance or accept `minconf` and `watchonly` arguments. |

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -53,7 +53,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listreceivedbylabel", 0, "minconf" },
     { "listreceivedbylabel", 1, "include_empty" },
     { "listreceivedbylabel", 2, "include_watchonly" },
-    { "getlabeladdress", 1, "force" },
     { "getbalance", 1, "minconf" },
     { "getbalance", 2, "include_watchonly" },
     { "getchaintips", 0, "count" },

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -40,7 +40,6 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         #
         # The following 'label' RPC methods are usable both with and without the
         # -deprecatedrpc=accounts switch enabled.
-        # - getlabeladdress
         # - getaddressesbylabel
         # - getreceivedbylabel
         # - listlabels
@@ -68,10 +67,6 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         self.log.info("- getaccountaddress")
         assert_raises_rpc_error(-32, "getaccountaddress is deprecated", self.nodes[0].getaccountaddress, "label0")
         self.nodes[1].getaccountaddress("label1")
-
-        self.log.info("- getlabeladdress")
-        self.nodes[0].getlabeladdress("label0")
-        self.nodes[1].getlabeladdress("label1")
 
         self.log.info("- getaddressesbyaccount")
         assert_raises_rpc_error(-32, "getaddressesbyaccount is deprecated", self.nodes[0].getaddressesbyaccount, "label0")


### PR DESCRIPTION
labels are associated with addresses (rather than addresses being
associated with labels, as was the case with accounts). The
getlabeladdress does not make sense in this model, so remove it.

getaccountaddress is still supported for one release as the accounts
API is deprecated.