### PR TITLE
Simplify include analysis by enforcing the developer guide's include syntax

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -622,8 +622,8 @@ namespace {
 
   - *Rationale*: Avoids confusion about the namespace context
 
-- Prefer `#include <primitives/transaction.h>` bracket syntax instead of
-  `#include "primitives/transactions.h"` quote syntax when possible.
+- Use `#include <primitives/transaction.h>` bracket syntax instead of
+  `#include "primitives/transactions.h"` quote syntax.
 
   - *Rationale*: Bracket syntax is less ambiguous because the preprocessor
     searches a fixed list of include directories without taking location of the

--- a/src/bench/merkle_root.cpp
+++ b/src/bench/merkle_root.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "bench.h"
+#include <bench/bench.h>
 
-#include "uint256.h"
-#include "random.h"
-#include "consensus/merkle.h"
+#include <uint256.h>
+#include <random.h>
+#include <consensus/merkle.h>
 
 static void MerkleRoot(benchmark::State& state)
 {

--- a/src/crypto/sha256_avx2.cpp
+++ b/src/crypto/sha256_avx2.cpp
@@ -7,8 +7,8 @@
 #include <x86intrin.h>
 #endif
 
-#include "crypto/sha256.h"
-#include "crypto/common.h"
+#include <crypto/sha256.h>
+#include <crypto/common.h>
 
 namespace sha256d64_avx2 {
 namespace {

--- a/src/crypto/sha256_sse41.cpp
+++ b/src/crypto/sha256_sse41.cpp
@@ -7,8 +7,8 @@
 #include <x86intrin.h>
 #endif
 
-#include "crypto/sha256.h"
-#include "crypto/common.h"
+#include <crypto/sha256.h>
+#include <crypto/common.h>
 
 namespace sha256d64_sse41 {
 namespace {

--- a/src/qt/proposalfilterproxy.cpp
+++ b/src/qt/proposalfilterproxy.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "proposalfilterproxy.h"
-#include "proposaltablemodel.h"
+#include <qt/proposalfilterproxy.h>
+#include <qt/proposaltablemodel.h>
 
 #include <cstdlib>
 

--- a/src/qt/proposalfilterproxy.h
+++ b/src/qt/proposalfilterproxy.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_QT_PROPOSALFILTERPROXY_H
 #define BITCOIN_QT_PROPOSALFILTERPROXY_H
 
-#include "amount.h"
+#include <amount.h>
 
 #include <QDateTime>
 #include <QSortFilterProxyModel>

--- a/src/qt/proposalrecord.cpp
+++ b/src/qt/proposalrecord.cpp
@@ -3,4 +3,4 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "proposalrecord.h"
+#include <qt/proposalrecord.h>

--- a/src/qt/proposalrecord.h
+++ b/src/qt/proposalrecord.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_QT_PROPOSALRECORD_H
 #define BITCOIN_QT_PROPOSALRECORD_H
 
-#include "amount.h"
-#include "uint256.h"
+#include <amount.h>
+#include <uint256.h>
 
 #include <QList>
 #include <QString>

--- a/src/qt/qrdialog.cpp
+++ b/src/qt/qrdialog.cpp
@@ -22,7 +22,7 @@
 #endif
 
 #if defined(HAVE_CONFIG_H)
-#include "config/chaincoin-config.h" /* for USE_QRCODE */
+#include <config/chaincoin-config.h> /* for USE_QRCODE */
 #endif
 
 #ifdef USE_QRCODE

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -1,9 +1,9 @@
 #include <boost/test/unit_test.hpp>
 
-#include "stdlib.h"
+#include <stdlib.h>
 
-#include "rpc/blockchain.cpp"
-#include "test/test_chaincoin.h"
+#include <rpc/blockchain.h>
+#include <test/test_chaincoin.h>
 
 /* Equality between doubles is imprecise. Comparison should be done
  * with a small threshold of tolerance, rather than exact equality.

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -2,14 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "wallet/wallet.h"
-#include "wallet/coinselection.h"
-#include "wallet/coincontrol.h"
-#include "amount.h"
-#include "primitives/transaction.h"
-#include "random.h"
-#include "test/test_bitcoin.h"
-#include "wallet/test/wallet_test_fixture.h"
+#include <wallet/wallet.h>
+#include <wallet/coinselection.h>
+#include <wallet/coincontrol.h>
+#include <amount.h>
+#include <primitives/transaction.h>
+#include <random.h>
+#include <test/test_bitcoin.h>
+#include <wallet/test/wallet_test_fixture.h>
 
 #include <boost/test/unit_test.hpp>
 #include <random>

--- a/src/zmq/zmqconfig.h
+++ b/src/zmq/zmqconfig.h
@@ -19,8 +19,8 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 
-#include "governance-object.h"
-#include "governance-vote.h"
+#include <governance-object.h>
+#include <governance-vote.h>
 
 void zmqError(const char *str);
 

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -6,9 +6,12 @@
 #
 # Check for duplicate includes.
 # Guard against accidental introduction of new Boost dependencies.
+# Check includes: Check for duplicate includes. Enforce bracket syntax includes.
+
+IGNORE_REGEXP="/(leveldb|secp256k1|univalue)/"
 
 filter_suffix() {
-    git ls-files | grep -E "^src/.*\.${1}"'$' | grep -Ev "/(leveldb|secp256k1|univalue)/"
+    git ls-files | grep -E "^src/.*\.${1}"'$' | grep -Ev "${IGNORE_REGEXP}"
 }
 
 EXIT_CODE=0
@@ -104,5 +107,13 @@ for EXPECTED_BOOST_INCLUDE in "${EXPECTED_BOOST_INCLUDES[@]}"; do
         EXIT_CODE=1
     fi
 done
+
+QUOTE_SYNTAX_INCLUDES=$(git grep '^#include "' -- "*.cpp" "*.h" | grep -Ev "${IGNORE_REGEXP}")
+if [[ ${QUOTE_SYNTAX_INCLUDES} != "" ]]; then
+    echo "Please use bracket syntax includes (\"#include <foo.h>\") instead of quote syntax includes:"
+    echo "${QUOTE_SYNTAX_INCLUDES}"
+    echo
+    EXIT_CODE=1
+fi
 
 exit ${EXIT_CODE}

--- a/test/no_nul.cpp
+++ b/test/no_nul.cpp
@@ -1,4 +1,4 @@
-#include "univalue.h"
+#include <univalue.h>
 
 int main (int argc, char *argv[])
 {

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -6,7 +6,7 @@
 
 #include <iostream>
 #include <string>
-#include "univalue.h"
+#include <univalue.h>
 
 using namespace std;
 


### PR DESCRIPTION
When analysing includes in the project it is often assumed that the preferred bracket include syntax (`#include <foo.h>`) mentioned in `developer-docs.md` is used consistently. @sipa:s excellent circular dependencies script [`circular-dependencies.py`](https://github.com/sipa/bitcoin/blob/50c69b78011c1bc55885ebfd216db60ed490ebea/contrib/devtools/circular-dependencies.py) (#13228) is an example of a script making this reasonable assumption.

This PR enables automatic Travis checking of the include syntax making sure that the bracket syntax includes (`#include <foo.h>`) is used consistently.