### PR TITLE
Docs: Improve readability of "Squashing commits"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,10 +109,10 @@ before it will be merged. The basic squashing workflow is shown below.
 
     git checkout your_branch_name
     git rebase -i HEAD~n
-    # n is normally the number of commits in the pull
-    # set commits from 'pick' to 'squash', save and quit
-    # on the next screen, edit/refine commit messages
-    # save and quit
+    # n is normally the number of commits in the pull request.
+    # Set commits (except the one in the first line) from 'pick' to 'squash', save and quit.
+    # On the next screen, edit/refine commit messages.
+    # Save and quit.
     git push -f # (force push to GitHub)
 
 If you have problems with squashing (or other workflows with `git`), you can


### PR DESCRIPTION
It was not easy to read the comment lines for me because I was not sure whether the sentence ended with the line or not ("pull set commits"?).
Therefore, dots had been invented and I have added them to signal the end of a sentence. Also begin New sentence with a capital letter.

I guess, not all 'pick' words should be replaced by 'squash'? At least I found [https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request](this) rebase/squash documentation helpful, where is written that the first line should not be changed.