### PR TITLE
Only set fNewBlock to true in AcceptBlock when we write to disk

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3500,7 +3500,6 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
         // request; don't process these.
         if (pindex->nChainWork < nMinimumChainWork) return true;
     }
-    if (fNewBlock) *fNewBlock = true;
 
     if (!CheckBlock(block, state, chainparams.GetConsensus()) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
@@ -3517,6 +3516,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
         GetMainSignals().NewPoWValidBlock(pindex, pblock);
 
     // Write block to history file
+    if (fNewBlock) *fNewBlock = true;
     try {
         CDiskBlockPos blockPos = SaveBlockToDisk(block, pindex->nHeight, chainparams, dbp);
         if (blockPos.IsNull()) {


### PR DESCRIPTION
The only affect this should have is fixing the return code in
submitblock in cases where a block fails ContextualCheckBlock and
not setting nLastBlockTime on peers that provide blocks which fail
ContextualCheckBlock (which is only used in eviction and cosmetic).