### PR TITLE
Log warning message when deprecated network name 'tor' is used (e.g. …

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -41,7 +41,11 @@ enum Network ParseNetwork(std::string net) {
     boost::to_lower(net);
     if (net == "ipv4") return NET_IPV4;
     if (net == "ipv6") return NET_IPV6;
-    if (net == "tor" || net == "onion")  return NET_TOR;
+    if (net == "onion") return NET_TOR;
+    if (net == "tor") {
+        LogPrintf("Warning: net name 'tor' is deprecated and will be removed in the future. You should use 'onion' instead.\n");
+        return NET_TOR;
+    }
     return NET_UNROUTABLE;
 }
 


### PR DESCRIPTION
…option onlynet=tor)