### PR TITLE
Break circular dependency: init -> * -> init by extracting shutdown.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -174,6 +174,7 @@ BITCOIN_CORE_H = \
   script/sigcache.h \
   script/sign.h \
   script/standard.h \
+  shutdown.h \
   streams.h \
   support/allocators/secure.h \
   support/allocators/zeroafterfree.h \
@@ -273,6 +274,7 @@ libbitcoin_server_a_SOURCES = \
   rpc/server.cpp \
   rpc/util.cpp \
   script/sigcache.cpp \
+  shutdown.cpp \
   timedata.cpp \
   torcontrol.cpp \
   txdb.cpp \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -34,8 +34,8 @@ nodist_bench_bench_chaincoin_SOURCES = $(GENERATED_TEST_FILES)
 bench_bench_chaincoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_chaincoin_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 bench_bench_chaincoin_LDADD = \
-  $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_WALLET) \
+  $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_COMMON) \
   $(LIBBITCOIN_UTIL) \
   $(LIBBITCOIN_CONSENSUS) \

--- a/src/chaincoind.cpp
+++ b/src/chaincoind.cpp
@@ -15,6 +15,7 @@
 #include <rpc/server.h>
 #include <init.h>
 #include <noui.h>
+#include <shutdown.h>
 #include <util.h>
 #include <masternodeconfig.h>
 #include <httpserver.h>

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -4,7 +4,7 @@
 
 #include <chainparams.h>
 #include <index/base.h>
-#include <init.h>
+#include <shutdown.h>
 #include <tinyformat.h>
 #include <ui_interface.h>
 #include <util.h>

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <index/txindex.h>
-#include <init.h>
+#include <shutdown.h>
 #include <ui_interface.h>
 #include <util.h>
 #include <validation.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -38,6 +38,7 @@
 #include <script/standard.h>
 #include <script/sigcache.h>
 #include <scheduler.h>
+#include <shutdown.h>
 #include <timedata.h>
 #include <txdb.h>
 #include <txmempool.h>
@@ -154,7 +155,7 @@ static const char* FEE_ESTIMATES_FILENAME="fee_estimates.dat";
 // created by AppInit() or the Qt main() function.
 //
 // A clean exit happens when StartShutdown() or the SIGTERM
-// signal handler sets fRequestShutdown, which makes main thread's
+// signal handler sets ShutdownRequested(), which makes main thread's
 // WaitForShutdown() interrupts the thread group.
 // And then, WaitForShutdown() makes all other on-going threads
 // in the thread group join the main thread.
@@ -163,20 +164,9 @@ static const char* FEE_ESTIMATES_FILENAME="fee_estimates.dat";
 // threads have exited.
 //
 // Shutdown for Qt is very similar, only it uses a QTimer to detect
-// fRequestShutdown getting set, and then does the normal Qt
+// ShutdownRequested() getting set, and then does the normal Qt
 // shutdown thing.
 //
-
-std::atomic<bool> fRequestShutdown(false);
-
-void StartShutdown()
-{
-    fRequestShutdown = true;
-}
-bool ShutdownRequested()
-{
-    return fRequestShutdown;
-}
 
 /**
  * This is a minimally invasive approach to shutdown on LevelDB read errors from the
@@ -356,7 +346,7 @@ void Shutdown()
 #ifndef WIN32
 static void HandleSIGTERM(int)
 {
-    fRequestShutdown = true;
+    StartShutdown();
 }
 
 static void HandleSIGHUP(int)
@@ -366,7 +356,7 @@ static void HandleSIGHUP(int)
 #else
 static BOOL WINAPI consoleCtrlHandler(DWORD dwCtrlType)
 {
-    fRequestShutdown = true;
+    StartShutdown();
     Sleep(INFINITE);
     return true;
 }
@@ -769,7 +759,7 @@ static void ThreadImport(std::vector<fs::path> vImportFiles)
     if (gArgs.GetArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
         LoadMempool();
     }
-    g_is_mempool_loaded = !fRequestShutdown;
+    g_is_mempool_loaded = !ShutdownRequested();
 }
 
 /** Sanity checks
@@ -1525,7 +1515,7 @@ bool AppInitMain()
     bool fLoaded = false;
     int64_t nStart = GetTimeMillis();
 
-    while (!fLoaded && !fRequestShutdown) {
+    while (!fLoaded && !ShutdownRequested()) {
         bool fReset = fReindex;
         std::string strLoadError;
 
@@ -1552,7 +1542,7 @@ bool AppInitMain()
                         CleanupBlockRevFiles();
                 }
 
-                if (fRequestShutdown) break;
+                if (ShutdownRequested()) break;
 
                 // LoadBlockIndex will load fHavePruned if we've ever removed a
                 // block file from disk.
@@ -1659,7 +1649,7 @@ bool AppInitMain()
             fLoaded = true;
         } while(false);
 
-        if (!fLoaded && !fRequestShutdown) {
+        if (!fLoaded && !ShutdownRequested()) {
             // first suggest a reindex
             if (!fReset) {
                 bool fRet = uiInterface.ThreadSafeQuestion(
@@ -1668,7 +1658,7 @@ bool AppInitMain()
                     "", CClientUIInterface::MSG_ERROR | CClientUIInterface::BTN_ABORT);
                 if (fRet) {
                     fReindex = true;
-                    fRequestShutdown = false;
+                    AbortShutdown();
                 } else {
                     LogPrintf("Aborted block database rebuild. Exiting.\n");
                     return false;
@@ -1682,8 +1672,7 @@ bool AppInitMain()
     // As LoadBlockIndex can take several minutes, it's possible the user
     // requested to kill the GUI during the last operation. If so, exit.
     // As the program has not fully started yet, Shutdown() is possibly overkill.
-    if (fRequestShutdown)
-    {
+    if (ShutdownRequested()) {
         LogPrintf("Shutdown requested. Exiting.\n");
         return false;
     }

--- a/src/init.h
+++ b/src/init.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2017 The Bitcoin Core developers
+// Copyright (c) 2009-2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -24,8 +24,6 @@ namespace boost
 class thread_group;
 } // namespace boost
 
-void StartShutdown();
-bool ShutdownRequested();
 /** Interrupt threads */
 void Interrupt();
 void Shutdown();

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -25,6 +25,7 @@
 #include <privatesend.h>
 #include <rpc/server.h>
 #include <scheduler.h>
+#include <shutdown.h>
 #include <sync.h>
 #include <txmempool.h>
 #include <ui_interface.h>

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -16,6 +16,7 @@
 #include <masternodeman.h>
 #include <messagesigner.h>
 #include <script/standard.h>
+#include <shutdown.h>
 #include <util.h>
 #include <walletinitinterface.h>
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -16,6 +16,7 @@
 #include <netmessagemaker.h>
 #include <scheduler.h>
 #include <script/standard.h>
+#include <shutdown.h>
 #include <ui_interface.h>
 #include <util.h>
 #include <warnings.h>

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -11,7 +11,6 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <hash.h>
-#include <init.h>
 #include <validation.h>
 #include <merkleblock.h>
 #include <netmessagemaker.h>

--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -7,12 +7,12 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <core_io.h>
-#include <init.h>
 #include <masternode-sync.h>
 #include <masternodeman.h>
 #include <netmessagemaker.h>
 #include <scheduler.h>
 #include <script/interpreter.h>
+#include <shutdown.h>
 #include <txmempool.h>
 #include <util.h>
 #include <utilmoneystr.h>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -30,7 +30,7 @@
 #include <qt/macdockiconhandler.h>
 #endif
 
-#include <init.h>
+#include <chainparams.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <ui_interface.h>

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -290,7 +290,7 @@ private Q_SLOTS:
     /** Simply calls showNormalIfMinimized(true) for use in SLOT() macro */
     void toggleHidden();
 
-    /** called by a timer to check if fRequestShutdown has been set **/
+    /** called by a timer to check if ShutdownRequested() has been set **/
     void detectShutdown();
 
     /** Show progress dialog e.g. for verifychain */

--- a/src/qt/chaincoin.cpp
+++ b/src/qt/chaincoin.cpp
@@ -28,7 +28,6 @@
 #endif
 #include <masternodeconfig.h>
 
-#include <init.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <rpc/server.h>

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -11,7 +11,6 @@
 #include <qt/platformstyle.h>
 #include <qt/walletmodel.h>
 
-#include <init.h>
 #include <key_io.h>
 #include <validation.h> // For strMessageMagic
 #include <wallet/wallet.h>

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -9,7 +9,6 @@
 #include <qt/networkstyle.h>
 
 #include <clientversion.h>
-#include <init.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>

--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -5,7 +5,7 @@
 #include <qt/winshutdownmonitor.h>
 
 #if defined(Q_OS_WIN)
-#include <init.h>
+#include <shutdown.h>
 #include <util.h>
 
 #include <windows.h>

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -12,7 +12,6 @@
 #include <consensus/params.h>
 #include <consensus/validation.h>
 #include <core_io.h>
-#include <init.h>
 #include <validation.h>
 #include <key_io.h>
 #include <miner.h>
@@ -22,6 +21,7 @@
 #include <rpc/blockchain.h>
 #include <rpc/mining.h>
 #include <rpc/server.h>
+#include <shutdown.h>
 #include <txmempool.h>
 #include <util.h>
 #include <utilstrencodings.h>

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -8,7 +8,6 @@
 #include <clientversion.h>
 #include <core_io.h>
 #include <crypto/ripemd160.h>
-#include <init.h>
 #include <key_io.h>
 #include <validation.h>
 #include <httpserver.h>

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -10,7 +10,6 @@
 #include <consensus/validation.h>
 #include <core_io.h>
 #include <index/txindex.h>
-#include <init.h>
 #include <keystore.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1,15 +1,14 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2018 The Bitcoin Core developers
-// Copyright (c) 2018 PM-Tech
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <rpc/server.h>
 
 #include <fs.h>
-#include <init.h>
 #include <key_io.h>
 #include <random.h>
+#include <shutdown.h>
 #include <sync.h>
 #include <ui_interface.h>
 #include <util.h>

--- a/src/shutdown.cpp
+++ b/src/shutdown.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <shutdown.h>
+
+#include <atomic>
+
+static std::atomic<bool> fRequestShutdown(false);
+
+void StartShutdown()
+{
+    fRequestShutdown = true;
+}
+void AbortShutdown()
+{
+    fRequestShutdown = false;
+}
+bool ShutdownRequested()
+{
+    return fRequestShutdown;
+}

--- a/src/shutdown.h
+++ b/src/shutdown.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SHUTDOWN_H
+#define BITCOIN_SHUTDOWN_H
+
+void StartShutdown();
+void AbortShutdown();
+bool ShutdownRequested();
+
+#endif

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2017 The Bitcoin Core developers
+// Copyright (c) 2009-2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,10 +9,10 @@
 #include <hash.h>
 #include <random.h>
 #include <pow.h>
+#include <shutdown.h>
 #include <uint256.h>
 #include <util.h>
 #include <ui_interface.h>
-#include <init.h>
 
 #include <stdint.h>
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2009-2018 The Bitcoin Core developers
 // Copyright (c) 2014-2017 The Dash Core developers
 // Copyright (c) 2018 PM-Tech
 // Distributed under the MIT software license, see the accompanying
@@ -19,7 +19,6 @@
 #include <cuckoocache.h>
 #include <hash.h>
 #include <index/txindex.h>
-#include <init.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
@@ -30,6 +29,7 @@
 #include <script/script.h>
 #include <script/sigcache.h>
 #include <script/standard.h>
+#include <shutdown.h>
 #include <timedata.h>
 #include <tinyformat.h>
 #include <txdb.h>

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -5,7 +5,6 @@
 
 #include <validationinterface.h>
 
-#include <init.h>
 #include <primitives/block.h>
 #include <scheduler.h>
 #include <sync.h>

--- a/src/wallet/privatesend-client.cpp
+++ b/src/wallet/privatesend-client.cpp
@@ -7,7 +7,6 @@
 #include <wallet/coincontrol.h>
 #include <consensus/validation.h>
 #include <core_io.h>
-#include <init.h>
 #include <masternode-payments.h>
 #include <masternode-sync.h>
 #include <masternodeman.h>
@@ -15,6 +14,7 @@
 #include <reverse_iterator.h>
 #include <scheduler.h>
 #include <script/sign.h>
+#include <shutdown.h>
 #include <txmempool.h>
 #include <util.h>
 #include <utilmoneystr.h>

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -23,6 +23,7 @@
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <script/sign.h>
+#include <shutdown.h>
 #include <timedata.h>
 #include <util.h>
 #include <utilmoneystr.h>
@@ -33,8 +34,6 @@
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
 #include <wallet/walletutil.h>
-
-#include <init.h>  // For StartShutdown
 
 #include <stdint.h>
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -13,7 +13,6 @@
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <fs.h>
-#include <init.h>
 #include <key.h>
 #include <key_io.h>
 #include <keystore.h>
@@ -26,6 +25,7 @@
 #include <primitives/transaction.h>
 #include <reverse_iterator.h>
 #include <script/script.h>
+#include <shutdown.h>
 #include <timedata.h>
 #include <txmempool.h>
 #include <utilmoneystr.h>


### PR DESCRIPTION
Most includers just wanted to react to pending shutdown.

Note Chaincoin: dips aren't entirely broken yet because of the provisional implementation of WalletInterface which need some rework

This isolates access to `fRequestShutdown` and limits access to the shutdown api functions, including the new `CancelShutdown` for setting it to `false`.