### PR TITLE
[Tests] Make p2p_segwit easier to debug

### DIFF
--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -237,7 +237,7 @@ class SegWitTest(BitcoinTestFramework):
         # Keep a place to store utxo's that can be used in later tests
         self.utxo = []
 
-        self.log.info("Starting tests before segwit lock in:")
+        self.segwit_status = 'defined'
 
         self.test_non_witness_transaction()
         self.test_unnecessary_witness_before_segwit_activation()
@@ -252,7 +252,6 @@ class SegWitTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         # At lockin, nothing should change.
-        self.log.info("Testing behavior post lockin, pre-activation")
         self.advance_to_segwit_lockin()
 
         # Retest unnecessary witnesses
@@ -264,7 +263,6 @@ class SegWitTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         # Now activate segwit
-        self.log.info("Testing behavior after segwit activation")
         self.advance_to_segwit_active()
 
         sync_blocks(self.nodes)
@@ -297,10 +295,14 @@ class SegWitTest(BitcoinTestFramework):
     def subtest(func):  # noqa: N805
         """Wraps the subtests for logging and state assertions."""
         def func_wrapper(self, *args, **kwargs):
-            self.log.info("Subtest: {}".format(func.__name__))
+            self.log.info("Subtest: {} (Segwit status = {})".format(func.__name__, self.segwit_status))
+            # Assert segwit status is as expected
+            assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], self.segwit_status)
             func(self, *args, **kwargs)
             # Each subtest should leave some utxos for the next subtest
             assert self.utxo
+            # Assert segwit status is as expected at end of subtest
+            assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], self.segwit_status)
 
         return func_wrapper
 
@@ -338,8 +340,6 @@ class SegWitTest(BitcoinTestFramework):
     @subtest
     def test_unnecessary_witness_before_segwit_activation(self):
         """Verify that blocks with witnesses are rejected before activation."""
-
-        assert(get_bip9_status(self.nodes[0], 'segwit')['status'] != 'active')
 
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
@@ -552,11 +552,10 @@ class SegWitTest(BitcoinTestFramework):
         height = self.nodes[0].getblockcount()
         # Will need to rewrite the tests here if we are past the first period
         assert(height < VB_PERIOD - 1)
-        # Genesis block is 'defined'.
-        assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'defined')
         # Advance to end of period, status should now be 'started'
         self.nodes[0].generate(VB_PERIOD - height - 1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'started')
+        self.segwit_status = 'started'
 
     @subtest
     def test_getblocktemplate_before_lockin(self):
@@ -612,7 +611,6 @@ class SegWitTest(BitcoinTestFramework):
         # signalling blocks, rather than just at the right period boundary.
 
         height = self.nodes[0].getblockcount()
-        assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'started')
         # Advance to end of period, and verify lock-in happens at the end
         self.nodes[0].generate(VB_PERIOD - 1)
         height = self.nodes[0].getblockcount()
@@ -620,6 +618,7 @@ class SegWitTest(BitcoinTestFramework):
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'started')
         self.nodes[0].generate(1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
+        self.segwit_status = 'locked_in'
 
     @subtest
     def test_witness_tx_relay_before_segwit_activation(self):
@@ -747,12 +746,12 @@ class SegWitTest(BitcoinTestFramework):
         # TODO: we could verify that activation only happens at the right threshold
         # of signalling blocks, rather than just at the right period boundary.
 
-        assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
         height = self.nodes[0].getblockcount()
         self.nodes[0].generate(VB_PERIOD - (height % VB_PERIOD) - 2)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
         self.nodes[0].generate(1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'active')
+        self.segwit_status = 'active'
 
     @subtest
     def test_p2sh_witness(self, segwit_activated):

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -75,6 +75,7 @@ from test_framework.util import (
     assert_equal,
     bytes_to_hex_str,
     connect_nodes,
+    disconnect_nodes,
     get_bip9_status,
     hex_str_to_bytes,
     sync_blocks,
@@ -237,37 +238,30 @@ class SegWitTest(BitcoinTestFramework):
         # Keep a place to store utxo's that can be used in later tests
         self.utxo = []
 
+        # Segwit status 'defined'
         self.segwit_status = 'defined'
 
         self.test_non_witness_transaction()
         self.test_unnecessary_witness_before_segwit_activation()
         self.test_v0_outputs_arent_spendable()
         self.test_block_relay()
-
-        # Advance to segwit being 'started'
         self.advance_to_segwit_started()
-        sync_blocks(self.nodes)
+
+        # Segwit status 'started'
+
         self.test_getblocktemplate_before_lockin()
-
-        sync_blocks(self.nodes)
-
-        # At lockin, nothing should change.
         self.advance_to_segwit_lockin()
 
-        # Retest unnecessary witnesses
+        # Segwit status 'locked_in'
+
         self.test_unnecessary_witness_before_segwit_activation()
         self.test_witness_tx_relay_before_segwit_activation()
         self.test_block_relay()
         self.test_standardness_v0()
-
-        sync_blocks(self.nodes)
-
-        # Now activate segwit
         self.advance_to_segwit_active()
 
-        sync_blocks(self.nodes)
+        # Segwit status 'active'
 
-        # Test P2SH witness handling again
         self.test_p2sh_witness()
         self.test_witness_commitments()
         self.test_block_malleability()
@@ -286,7 +280,6 @@ class SegWitTest(BitcoinTestFramework):
         self.test_signature_version_1()
         self.test_non_standard_witness_blinding()
         self.test_non_standard_witness()
-        sync_blocks(self.nodes)
         self.test_upgrade_after_activation()
         self.test_witness_sigops()
 
@@ -301,6 +294,7 @@ class SegWitTest(BitcoinTestFramework):
             func(self, *args, **kwargs)
             # Each subtest should leave some utxos for the next subtest
             assert self.utxo
+            sync_blocks(self.nodes)
             # Assert segwit status is as expected at end of subtest
             assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], self.segwit_status)
 
@@ -368,8 +362,6 @@ class SegWitTest(BitcoinTestFramework):
         self.test_node.send_message(msg_block(block))
         self.test_node.sync_with_ping()
         assert_equal(self.nodes[0].getbestblockhash(), block.hash)
-
-        sync_blocks(self.nodes)
 
         # Update our utxo list; we spent the first entry.
         self.utxo.pop(0)
@@ -483,6 +475,11 @@ class SegWitTest(BitcoinTestFramework):
         witness, and so can't be spent before segwit activation (the point at which
         blocks are permitted to contain witnesses)."""
 
+        # node2 doesn't need to be connected for this test.
+        # (If it's connected, node0 may propogate an invalid block to it over
+        # compact blocks and the nodes would have inconsistent tips.)
+        disconnect_nodes(self.nodes[0], 2)
+
         # Create two outputs, a p2wsh and p2sh-p2wsh
         witness_program = CScript([OP_TRUE])
         witness_hash = sha256(witness_program)
@@ -542,6 +539,8 @@ class SegWitTest(BitcoinTestFramework):
             # empty witness)' (otherwise).
             # TODO: support multiple acceptable reject reasons.
             test_witness_block(self.nodes[0], self.test_node, block, accepted=False, with_witness=False)
+
+        connect_nodes(self.nodes[0], 2)
 
         self.utxo.pop(0)
         self.utxo.append(UTXO(txid, 2, value))
@@ -1964,9 +1963,6 @@ class SegWitTest(BitcoinTestFramework):
     @subtest
     def test_upgrade_after_activation(self):
         """Test the behavior of starting up a segwit-aware node after the softfork has activated."""
-
-        # Make sure the nodes are all up
-        sync_blocks(self.nodes)
 
         # Restart with the new binary
         self.stop_node(2)

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -242,7 +242,7 @@ class SegWitTest(BitcoinTestFramework):
         self.test_non_witness_transaction()
         self.test_unnecessary_witness_before_segwit_activation()
         self.test_v0_outputs_arent_spendable()
-        self.test_block_relay(segwit_activated=False)
+        self.test_block_relay()
 
         # Advance to segwit being 'started'
         self.advance_to_segwit_started()
@@ -257,8 +257,8 @@ class SegWitTest(BitcoinTestFramework):
         # Retest unnecessary witnesses
         self.test_unnecessary_witness_before_segwit_activation()
         self.test_witness_tx_relay_before_segwit_activation()
-        self.test_block_relay(segwit_activated=False)
-        self.test_standardness_v0(segwit_activated=False)
+        self.test_block_relay()
+        self.test_standardness_v0()
 
         sync_blocks(self.nodes)
 
@@ -268,7 +268,7 @@ class SegWitTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         # Test P2SH witness handling again
-        self.test_p2sh_witness(segwit_activated=True)
+        self.test_p2sh_witness()
         self.test_witness_commitments()
         self.test_block_malleability()
         self.test_witness_block_size()
@@ -277,9 +277,9 @@ class SegWitTest(BitcoinTestFramework):
         self.test_max_witness_push_length()
         self.test_max_witness_program_length()
         self.test_witness_input_length()
-        self.test_block_relay(segwit_activated=True)
+        self.test_block_relay()
         self.test_tx_relay_after_segwit_activation()
-        self.test_standardness_v0(segwit_activated=True)
+        self.test_standardness_v0()
         self.test_segwit_versions()
         self.test_premature_coinbase_witness_spend()
         self.test_uncompressed_pubkey()
@@ -287,7 +287,7 @@ class SegWitTest(BitcoinTestFramework):
         self.test_non_standard_witness_blinding()
         self.test_non_standard_witness()
         sync_blocks(self.nodes)
-        self.test_upgrade_after_activation(node_id=2)
+        self.test_upgrade_after_activation()
         self.test_witness_sigops()
 
     # Individual tests
@@ -376,7 +376,7 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.append(UTXO(tx.sha256, 0, tx.vout[0].nValue))
 
     @subtest
-    def test_block_relay(self, segwit_activated):
+    def test_block_relay(self):
         """Test that block requests to NODE_WITNESS peer are with MSG_WITNESS_FLAG.
 
         This is true regardless of segwit activation.
@@ -410,7 +410,7 @@ class SegWitTest(BitcoinTestFramework):
 
         # Check that we can getdata for witness blocks or regular blocks,
         # and the right thing happens.
-        if not segwit_activated:
+        if self.segwit_status != 'active':
             # Before activation, we should be able to request old blocks with
             # or without witness, and they should be the same.
             chain_height = self.nodes[0].getblockcount()
@@ -663,7 +663,7 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.append(UTXO(tx_hash, 0, tx_value))
 
     @subtest
-    def test_standardness_v0(self, segwit_activated):
+    def test_standardness_v0(self):
         """Test V0 txout standardness.
 
         V0 segwit outputs and inputs are always standard.
@@ -722,7 +722,7 @@ class SegWitTest(BitcoinTestFramework):
         tx3.wit.vtxinwit.append(CTxInWitness())
         tx3.wit.vtxinwit[0].scriptWitness.stack = [witness_program]
         tx3.rehash()
-        if not segwit_activated:
+        if self.segwit_status != 'active':
             # Just check mempool acceptance, but don't add the transaction to the mempool, since witness is disallowed
             # in blocks and the tx is impossible to mine right now.
             assert_equal(self.nodes[0].testmempoolaccept([bytes_to_hex_str(tx3.serialize_with_witness())]), [{'txid': tx3.hash, 'allowed': True}])
@@ -754,7 +754,7 @@ class SegWitTest(BitcoinTestFramework):
         self.segwit_status = 'active'
 
     @subtest
-    def test_p2sh_witness(self, segwit_activated):
+    def test_p2sh_witness(self):
         """Test P2SH wrapped witness programs."""
 
         # Prepare the p2sh-wrapped witness output
@@ -775,7 +775,7 @@ class SegWitTest(BitcoinTestFramework):
         test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx, with_witness=False, accepted=True)
         block = self.build_next_block()
         self.update_witness_block_with_transactions(block, [tx])
-        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True, with_witness=segwit_activated)
+        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True, with_witness=True)
         sync_blocks(self.nodes)
 
         # Now test attempts to spend the output.
@@ -804,7 +804,7 @@ class SegWitTest(BitcoinTestFramework):
         spend_tx.wit.vtxinwit[0].scriptWitness.stack = [b'a', witness_program]
 
         # Verify mempool acceptance
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, spend_tx, with_witness=True, accepted=segwit_activated)
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, spend_tx, with_witness=True, accepted=True)
         block = self.build_next_block()
         self.update_witness_block_with_transactions(block, [spend_tx])
 
@@ -812,10 +812,7 @@ class SegWitTest(BitcoinTestFramework):
         # This no longer works before activation, because SCRIPT_VERIFY_WITNESS
         # is always set.
         # TODO: rewrite this test to make clear that it only works after activation.
-        if segwit_activated:
-            test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
-        else:
-            test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True, with_witness=False)
+        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
 
         # Update self.utxo
         self.utxo.pop(0)
@@ -1965,30 +1962,28 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
 
     @subtest
-    def test_upgrade_after_activation(self, node_id):
+    def test_upgrade_after_activation(self):
         """Test the behavior of starting up a segwit-aware node after the softfork has activated."""
-
-        assert(node_id != 0)  # node0 is assumed to be a segwit-active bitcoind
 
         # Make sure the nodes are all up
         sync_blocks(self.nodes)
 
         # Restart with the new binary
-        self.stop_node(node_id)
-        self.start_node(node_id, extra_args=["-vbparams=segwit:0:999999999999"])
-        connect_nodes(self.nodes[0], node_id)
+        self.stop_node(2)
+        self.start_node(2, extra_args=["-vbparams=segwit:0:999999999999"])
+        connect_nodes(self.nodes[0], 2)
 
         sync_blocks(self.nodes)
 
         # Make sure that this peer thinks segwit has activated.
-        assert(get_bip9_status(self.nodes[node_id], 'segwit')['status'] == "active")
+        assert(get_bip9_status(self.nodes[2], 'segwit')['status'] == "active")
 
         # Make sure this peer's blocks match those of node0.
-        height = self.nodes[node_id].getblockcount()
+        height = self.nodes[2].getblockcount()
         while height >= 0:
-            block_hash = self.nodes[node_id].getblockhash(height)
+            block_hash = self.nodes[2].getblockhash(height)
             assert_equal(block_hash, self.nodes[0].getblockhash(height))
-            assert_equal(self.nodes[0].getblock(block_hash), self.nodes[node_id].getblock(block_hash))
+            assert_equal(self.nodes[0].getblock(block_hash), self.nodes[2].getblock(block_hash))
             height -= 1
 
     @subtest

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -229,16 +229,17 @@ class SegWitTest(BitcoinTestFramework):
         # self.std_node is for testing node1 (fRequireStandard=true)
         self.std_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK | NODE_WITNESS)
 
+        for conn in (self.test_node, self.old_node, self.std_node):
+            conn.wait_for_verack()
+
+        assert self.test_node.nServices & NODE_WITNESS != 0
+
         # Keep a place to store utxo's that can be used in later tests
         self.utxo = []
 
-        # Test logic begins here
-        self.test_node.wait_for_verack()
-
         self.log.info("Starting tests before segwit lock in:")
 
-        self.test_witness_services()  # Verifies NODE_WITNESS
-        self.test_non_witness_transaction()  # non-witness tx's are accepted
+        self.test_non_witness_transaction()
         self.test_unnecessary_witness_before_segwit_activation()
         self.test_v0_outputs_arent_spendable()
         self.test_block_relay(segwit_activated=False)
@@ -298,12 +299,10 @@ class SegWitTest(BitcoinTestFramework):
         def func_wrapper(self, *args, **kwargs):
             self.log.info("Subtest: {}".format(func.__name__))
             func(self, *args, **kwargs)
+            # Each subtest should leave some utxos for the next subtest
+            assert self.utxo
 
         return func_wrapper
-
-    def test_witness_services(self):
-        self.log.info("Verifying NODE_WITNESS service bit")
-        assert((self.test_node.nServices & NODE_WITNESS) != 0)
 
     @subtest
     def test_non_witness_transaction(self):
@@ -340,9 +339,6 @@ class SegWitTest(BitcoinTestFramework):
     def test_unnecessary_witness_before_segwit_activation(self):
         """Verify that blocks with witnesses are rejected before activation."""
 
-        # For now, rely on earlier tests to have created at least one utxo for
-        # us to use
-        assert(len(self.utxo) > 0)
         assert(get_bip9_status(self.nodes[0], 'segwit')['status'] != 'active')
 
         tx = CTransaction()
@@ -486,8 +482,6 @@ class SegWitTest(BitcoinTestFramework):
         Consequently, version 0 witness outputs are never spendable without
         witness, and so can't be spent before segwit activation (the point at which
         blocks are permitted to contain witnesses)."""
-
-        assert len(self.utxo), "self.utxo is empty"
 
         # Create two outputs, a p2wsh and p2sh-p2wsh
         witness_program = CScript([OP_TRUE])
@@ -633,7 +627,6 @@ class SegWitTest(BitcoinTestFramework):
         # Generate a transaction that doesn't require a witness, but send it
         # with a witness.  Should be rejected for premature-witness, but should
         # not be added to recently rejected list.
-        assert(len(self.utxo))
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
         tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))
@@ -676,8 +669,6 @@ class SegWitTest(BitcoinTestFramework):
 
         V0 segwit outputs and inputs are always standard.
         V0 segwit inputs may only be mined after activation, but not before."""
-
-        assert(len(self.utxo))
 
         witness_program = CScript([OP_TRUE])
         witness_hash = sha256(witness_program)
@@ -766,8 +757,6 @@ class SegWitTest(BitcoinTestFramework):
     @subtest
     def test_p2sh_witness(self, segwit_activated):
         """Test P2SH wrapped witness programs."""
-
-        assert(len(self.utxo))
 
         # Prepare the p2sh-wrapped witness output
         witness_program = CScript([OP_DROP, OP_TRUE])
@@ -862,7 +851,6 @@ class SegWitTest(BitcoinTestFramework):
         test_witness_block(self.nodes[0].rpc, self.test_node, block_2, accepted=True)
 
         # Now test commitments with actual transactions
-        assert (len(self.utxo) > 0)
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
 
@@ -1082,8 +1070,6 @@ class SegWitTest(BitcoinTestFramework):
     def test_extra_witness_data(self):
         """Test extra witness data in a transaction."""
 
-        assert(len(self.utxo) > 0)
-
         block = self.build_next_block()
 
         witness_program = CScript([OP_DROP, OP_TRUE])
@@ -1158,7 +1144,6 @@ class SegWitTest(BitcoinTestFramework):
         """Test that witness stack can only allow up to 520 byte pushes."""
 
         MAX_SCRIPT_ELEMENT_SIZE = 520
-        assert(len(self.utxo))
 
         block = self.build_next_block()
 
@@ -1197,7 +1182,6 @@ class SegWitTest(BitcoinTestFramework):
     def test_max_witness_program_length(self):
         """Test that witness outputs greater than 10kB can't be spent."""
 
-        assert(len(self.utxo))
         MAX_PROGRAM_LENGTH = 10000
 
         # This program is 19 max pushes (9937 bytes), then 64 more opcode-bytes.
@@ -1245,8 +1229,6 @@ class SegWitTest(BitcoinTestFramework):
     @subtest
     def test_witness_input_length(self):
         """Test that vin length must match vtxinwit length."""
-
-        assert(len(self.utxo))
 
         witness_program = CScript([OP_DROP, OP_TRUE])
         witness_hash = sha256(witness_program)
@@ -1338,7 +1320,6 @@ class SegWitTest(BitcoinTestFramework):
         # Generate a transaction that doesn't require a witness, but send it
         # with a witness.  Should be rejected because we can't use a witness
         # when spending a non-witness output.
-        assert(len(self.utxo))
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
         tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))
@@ -1427,7 +1408,6 @@ class SegWitTest(BitcoinTestFramework):
         Future segwit version transactions are non-standard, but valid in blocks.
         Can run this before and after segwit activation."""
 
-        assert(len(self.utxo))
         num_tests = 17  # will test OP_0, OP1, ..., OP_16
         if (len(self.utxo) < num_tests):
             tx = CTransaction()
@@ -1558,7 +1538,6 @@ class SegWitTest(BitcoinTestFramework):
         pubkey = CPubKey(key.get_pubkey())
         assert_equal(len(pubkey), 65)  # This should be an uncompressed pubkey
 
-        assert(len(self.utxo) > 0)
         utxo = self.utxo.pop(0)
 
         # Test 1: P2WPKH
@@ -1662,7 +1641,6 @@ class SegWitTest(BitcoinTestFramework):
         script_pubkey = CScript([OP_0, witness_hash])
 
         # First create a witness output for use in the tests.
-        assert(len(self.utxo))
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
         tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, script_pubkey))
@@ -1836,7 +1814,6 @@ class SegWitTest(BitcoinTestFramework):
     @subtest
     def test_non_standard_witness_blinding(self):
         """Test behavior of unnecessary witnesses in transactions does not blind the node for the transaction"""
-        assert (len(self.utxo) > 0)
 
         # Create a p2sh output -- this is so we can pass the standardness
         # rules (an anyone-can-spend OP_TRUE would be rejected, if not wrapped
@@ -1902,7 +1879,6 @@ class SegWitTest(BitcoinTestFramework):
 
         p2wsh_scripts = []
 
-        assert(len(self.utxo))
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
 
@@ -2019,8 +1995,6 @@ class SegWitTest(BitcoinTestFramework):
     @subtest
     def test_witness_sigops(self):
         """Test sigop counting is correct inside witnesses."""
-
-        assert(len(self.utxo))
 
         # Keep this under MAX_OPS_PER_SCRIPT (201)
         witness_program = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKMULTISIG] * 5 + [OP_CHECKSIG] * 193 + [OP_ENDIF])

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -3,17 +3,84 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test segwit transactions and blocks on P2P network."""
+from binascii import hexlify
+import math
+import random
+import struct
+import time
 
-from test_framework.mininode import *
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.script import *
 from test_framework.blocktools import create_block, create_coinbase, add_witness_commitment, get_witness_script, WITNESS_COMMITMENT_HEADER
 from test_framework.key import CECKey, CPubKey
-import math
-import time
-import random
-from binascii import hexlify
+from test_framework.messages import (
+    BIP125_SEQUENCE_NUMBER,
+    CBlock,
+    CBlockHeader,
+    CInv,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxInWitness,
+    CTxOut,
+    CTxWitness,
+    MAX_BLOCK_BASE_SIZE,
+    MSG_WITNESS_FLAG,
+    NODE_NETWORK,
+    NODE_WITNESS,
+    msg_block,
+    msg_getdata,
+    msg_headers,
+    msg_inv,
+    msg_tx,
+    msg_witness_block,
+    msg_witness_tx,
+    ser_uint256,
+    ser_vector,
+    sha256,
+    uint256_from_str,
+)
+from test_framework.mininode import (
+    P2PInterface,
+    mininode_lock,
+    network_thread_start,
+)
+from test_framework.script import (
+    CScript,
+    CScriptNum,
+    CScriptOp,
+    OP_0,
+    OP_1,
+    OP_16,
+    OP_2DROP,
+    OP_CHECKMULTISIG,
+    OP_CHECKSIG,
+    OP_DROP,
+    OP_DUP,
+    OP_ELSE,
+    OP_ENDIF,
+    OP_EQUAL,
+    OP_EQUALVERIFY,
+    OP_HASH160,
+    OP_IF,
+    OP_RETURN,
+    OP_TRUE,
+    SIGHASH_ALL,
+    SIGHASH_ANYONECANPAY,
+    SIGHASH_NONE,
+    SIGHASH_SINGLE,
+    SegwitVersion1SignatureHash,
+    SignatureHash,
+    hash160,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    bytes_to_hex_str,
+    connect_nodes,
+    get_bip9_status,
+    hex_str_to_bytes,
+    sync_blocks,
+    sync_mempools,
+)
 
 # The versionbit bit used to signal activation of SegWit
 VB_WITNESS_BIT = 1
@@ -30,7 +97,7 @@ def get_virtual_size(witness_block):
     base_size = len(witness_block.serialize(with_witness=False))
     total_size = len(witness_block.serialize(with_witness=True))
     # the "+3" is so we round up
-    vsize = int((3*base_size + total_size + 3)/4)
+    vsize = int((3 * base_size + total_size + 3) / 4)
     return vsize
 
 def test_transaction_acceptance(rpc, p2p, tx, with_witness, accepted, reason=None):
@@ -44,7 +111,7 @@ def test_transaction_acceptance(rpc, p2p, tx, with_witness, accepted, reason=Non
     p2p.send_message(tx_message)
     p2p.sync_with_ping()
     assert_equal(tx.hash in rpc.getrawmempool(), accepted)
-    if (reason != None and not accepted):
+    if (reason is not None and not accepted):
         # Check the rejection reason as well.
         with mininode_lock:
             assert_equal(p2p.last_message["reject"].reason, reason)
@@ -60,7 +127,7 @@ def test_witness_block(rpc, p2p, block, accepted, with_witness=True, reason=None
         p2p.send_message(msg_block(block))
     p2p.sync_with_ping()
     assert_equal(rpc.getbestblockhash() == block.hash, accepted)
-    if (reason != None and not accepted):
+    if (reason is not None and not accepted):
         # Check the rejection reason as well.
         with mininode_lock:
             assert_equal(p2p.last_message["reject"].reason, reason)
@@ -89,7 +156,7 @@ class TestP2PConn(P2PInterface):
             self.last_message.pop("getdata", None)
             self.last_message.pop("getheaders", None)
         msg = msg_headers()
-        msg.headers = [ CBlockHeader(block) ]
+        msg.headers = [CBlockHeader(block)]
         if use_header:
             self.send_message(msg)
         else:
@@ -107,21 +174,21 @@ class TestP2PConn(P2PInterface):
 
 # Used to keep track of anyone-can-spend outputs that we can use in the tests
 class UTXO():
-    def __init__(self, sha256, n, nValue):
+    def __init__(self, sha256, n, value):
         self.sha256 = sha256
         self.n = n
-        self.nValue = nValue
+        self.nValue = value
 
 # Helper for getting the script associated with a P2PKH
-def GetP2PKHScript(pubkeyhash):
+def get_p2pkh_script(pubkeyhash):
     return CScript([CScriptOp(OP_DUP), CScriptOp(OP_HASH160), pubkeyhash, CScriptOp(OP_EQUALVERIFY), CScriptOp(OP_CHECKSIG)])
 
 # Add signature for a P2PK witness program.
-def sign_P2PK_witness_input(script, txTo, inIdx, hashtype, value, key):
-    tx_hash = SegwitVersion1SignatureHash(script, txTo, inIdx, hashtype, value)
+def sign_p2pk_witness_input(script, tx_to, in_idx, hashtype, value, key):
+    tx_hash = SegwitVersion1SignatureHash(script, tx_to, in_idx, hashtype, value)
     signature = key.sign(tx_hash) + chr(hashtype).encode('latin-1')
-    txTo.wit.vtxinwit[inIdx].scriptWitness.stack = [signature, script]
-    txTo.rehash()
+    tx_to.wit.vtxinwit[in_idx].scriptWitness.stack = [signature, script]
+    tx_to.rehash()
 
 
 class SegWitTest(BitcoinTestFramework):
@@ -139,12 +206,12 @@ class SegWitTest(BitcoinTestFramework):
 
     ''' Helpers '''
     # Build a block on top of node0's tip.
-    def build_next_block(self, nVersion=4):
+    def build_next_block(self, version=4):
         tip = self.nodes[0].getbestblockhash()
         height = self.nodes[0].getblockcount() + 1
         block_time = self.nodes[0].getblockheader(tip)["mediantime"] + 1
         block = create_block(int(tip, 16), create_coinbase(height), block_time)
-        block.nVersion = nVersion
+        block.version = version
         block.rehash()
         return block
 
@@ -160,20 +227,19 @@ class SegWitTest(BitcoinTestFramework):
         self.log.info("Verifying NODE_WITNESS service bit")
         assert((self.test_node.nServices & NODE_WITNESS) != 0)
 
-
     # See if sending a regular transaction works, and create a utxo
     # to use in later tests.
     def test_non_witness_transaction(self):
         # Mine a block with an anyone-can-spend coinbase,
         # let it mature, then try to spend it.
         self.log.info("Testing non-witness transaction")
-        block = self.build_next_block(nVersion=1)
+        block = self.build_next_block(version=1)
         block.solve()
         self.test_node.send_message(msg_block(block))
-        self.test_node.sync_with_ping() # make sure the block was processed
+        self.test_node.sync_with_ping()  # make sure the block was processed
         txid = block.vtx[0].sha256
 
-        self.nodes[0].generate(99) # let the block mature
+        self.nodes[0].generate(99)  # let the block mature
 
         # Create a transaction that spends the coinbase
         tx = CTransaction()
@@ -186,12 +252,11 @@ class SegWitTest(BitcoinTestFramework):
         assert_equal(msg_tx(tx).serialize(), msg_witness_tx(tx).serialize())
 
         self.test_node.send_message(msg_witness_tx(tx))
-        self.test_node.sync_with_ping() # make sure the tx was processed
+        self.test_node.sync_with_ping()  # make sure the tx was processed
         assert(tx.hash in self.nodes[0].getrawmempool())
         # Save this transaction for later
-        self.utxo.append(UTXO(tx.sha256, 0, 49*100000000))
+        self.utxo.append(UTXO(tx.sha256, 0, 49 * 100000000))
         self.nodes[0].generate(1)
-
 
     # Verify that blocks with witnesses are rejected before activation.
     def test_unnecessary_witness_before_segwit_activation(self):
@@ -203,7 +268,7 @@ class SegWitTest(BitcoinTestFramework):
 
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        tx.vout.append(CTxOut(self.utxo[0].nValue-1000, CScript([OP_TRUE])))
+        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, CScript([OP_TRUE])))
         tx.wit.vtxinwit.append(CTxInWitness())
         tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([CScriptNum(1)])]
 
@@ -213,7 +278,7 @@ class SegWitTest(BitcoinTestFramework):
         assert(tx.sha256 != tx.calc_sha256(with_witness=True))
 
         # Construct a segwit-signaling block that includes the transaction.
-        block = self.build_next_block(nVersion=(VB_TOP_BITS|(1 << VB_WITNESS_BIT)))
+        block = self.build_next_block(version=(VB_TOP_BITS | (1 << VB_WITNESS_BIT)))
         self.update_witness_block_with_transactions(block, [tx])
         # Sending witness data before activation is not allowed (anti-spam
         # rule).
@@ -221,7 +286,7 @@ class SegWitTest(BitcoinTestFramework):
         # TODO: fix synchronization so we can test reject reason
         # Right now, bitcoind delays sending reject messages for blocks
         # until the future, making synchronization here difficult.
-        #assert_equal(self.test_node.last_message["reject"].reason, "unexpected-witness")
+        # assert_equal(self.test_node.last_message["reject"].reason, "unexpected-witness")
 
         # But it should not be permanently marked bad...
         # Resend without witness information.
@@ -250,16 +315,16 @@ class SegWitTest(BitcoinTestFramework):
         # Create two outputs, a p2wsh and p2sh-p2wsh
         witness_program = CScript([OP_TRUE])
         witness_hash = sha256(witness_program)
-        scriptPubKey = CScript([OP_0, witness_hash])
+        script_pubkey = CScript([OP_0, witness_hash])
 
-        p2sh_pubkey = hash160(scriptPubKey)
-        p2sh_scriptPubKey = CScript([OP_HASH160, p2sh_pubkey, OP_EQUAL])
+        p2sh_pubkey = hash160(script_pubkey)
+        p2sh_script_pubkey = CScript([OP_HASH160, p2sh_pubkey, OP_EQUAL])
 
         value = self.utxo[0].nValue // 3
 
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b'')]
-        tx.vout = [CTxOut(value, scriptPubKey), CTxOut(value, p2sh_scriptPubKey)]
+        tx.vout = [CTxOut(value, script_pubkey), CTxOut(value, p2sh_script_pubkey)]
         tx.vout.append(CTxOut(value, CScript([OP_TRUE])))
         tx.rehash()
         txid = tx.sha256
@@ -269,7 +334,7 @@ class SegWitTest(BitcoinTestFramework):
         self.update_witness_block_with_transactions(block, [tx])
         # Verify that segwit isn't activated. A block serialized with witness
         # should be rejected prior to activation.
-        test_witness_block(self.nodes[0], self.test_node, block, accepted=False, with_witness=True, reason = b'unexpected-witness')
+        test_witness_block(self.nodes[0], self.test_node, block, accepted=False, with_witness=True, reason=b'unexpected-witness')
         # Now send the block without witness. It should be accepted
         test_witness_block(self.nodes[0], self.test_node, block, accepted=True, with_witness=False)
 
@@ -282,7 +347,7 @@ class SegWitTest(BitcoinTestFramework):
         p2wsh_tx.rehash()
 
         p2sh_p2wsh_tx = CTransaction()
-        p2sh_p2wsh_tx.vin = [CTxIn(COutPoint(txid, 1), CScript([scriptPubKey]))]
+        p2sh_p2wsh_tx.vin = [CTxIn(COutPoint(txid, 1), CScript([script_pubkey]))]
         p2sh_p2wsh_tx.vout = [CTxOut(value, CScript([OP_TRUE]))]
         p2sh_p2wsh_tx.wit.vtxinwit.append(CTxInWitness())
         p2sh_p2wsh_tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_TRUE])]
@@ -318,7 +383,7 @@ class SegWitTest(BitcoinTestFramework):
         # Genesis block is 'defined'.
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'defined')
         # Advance to end of period, status should now be 'started'
-        self.nodes[0].generate(VB_PERIOD-height-1)
+        self.nodes[0].generate(VB_PERIOD - height - 1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'started')
 
     # Mine enough blocks to lock in segwit, but don't activate.
@@ -328,13 +393,12 @@ class SegWitTest(BitcoinTestFramework):
         height = self.nodes[0].getblockcount()
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'started')
         # Advance to end of period, and verify lock-in happens at the end
-        self.nodes[0].generate(VB_PERIOD-1)
+        self.nodes[0].generate(VB_PERIOD - 1)
         height = self.nodes[0].getblockcount()
         assert((height % VB_PERIOD) == VB_PERIOD - 2)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'started')
         self.nodes[0].generate(1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
-
 
     # Mine enough blocks to activate segwit.
     # TODO: we could verify that activation only happens at the right threshold
@@ -342,11 +406,10 @@ class SegWitTest(BitcoinTestFramework):
     def advance_to_segwit_active(self):
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
         height = self.nodes[0].getblockcount()
-        self.nodes[0].generate(VB_PERIOD - (height%VB_PERIOD) - 2)
+        self.nodes[0].generate(VB_PERIOD - (height % VB_PERIOD) - 2)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
         self.nodes[0].generate(1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'active')
-
 
     # This test can only be run after segwit has activated
     def test_witness_commitments(self):
@@ -382,14 +445,14 @@ class SegWitTest(BitcoinTestFramework):
         # Let's construct a witness program
         witness_program = CScript([OP_TRUE])
         witness_hash = sha256(witness_program)
-        scriptPubKey = CScript([OP_0, witness_hash])
-        tx.vout.append(CTxOut(self.utxo[0].nValue-1000, scriptPubKey))
+        script_pubkey = CScript([OP_0, witness_hash])
+        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, script_pubkey))
         tx.rehash()
 
         # tx2 will spend tx1, and send back to a regular anyone-can-spend address
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue-1000, witness_program))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, witness_program))
         tx2.wit.vtxinwit.append(CTxInWitness())
         tx2.wit.vtxinwit[0].scriptWitness.stack = [witness_program]
         tx2.rehash()
@@ -417,7 +480,7 @@ class SegWitTest(BitcoinTestFramework):
         block_3.vtx[0].rehash()
         block_3.hashMerkleRoot = block_3.calc_merkle_root()
         block_3.rehash()
-        assert(len(block_3.vtx[0].vout) == 4) # 3 OP_returns
+        assert(len(block_3.vtx[0].vout) == 4)  # 3 OP_returns
         block_3.solve()
         test_witness_block(self.nodes[0].rpc, self.test_node, block_3, accepted=True)
 
@@ -426,7 +489,7 @@ class SegWitTest(BitcoinTestFramework):
         block_4 = self.build_next_block()
         tx3 = CTransaction()
         tx3.vin.append(CTxIn(COutPoint(tx2.sha256, 0), b""))
-        tx3.vout.append(CTxOut(tx.vout[0].nValue-1000, witness_program))
+        tx3.vout.append(CTxOut(tx.vout[0].nValue - 1000, witness_program))
         tx3.rehash()
         block_4.vtx.append(tx3)
         block_4.hashMerkleRoot = block_4.calc_merkle_root()
@@ -436,7 +499,6 @@ class SegWitTest(BitcoinTestFramework):
         # Update available utxo's for use in later test.
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
-
 
     def test_block_malleability(self):
         self.log.info("Testing witness block malleability")
@@ -448,7 +510,7 @@ class SegWitTest(BitcoinTestFramework):
         add_witness_commitment(block)
         block.solve()
 
-        block.vtx[0].wit.vtxinwit[0].scriptWitness.stack.append(b'a'*5000000)
+        block.vtx[0].wit.vtxinwit[0].scriptWitness.stack.append(b'a' * 5000000)
         assert(get_virtual_size(block) > MAX_BLOCK_BASE_SIZE)
 
         # We can't send over the p2p network, because this is too big to relay
@@ -471,13 +533,12 @@ class SegWitTest(BitcoinTestFramework):
 
         # Change the nonce -- should not cause the block to be permanently
         # failed
-        block.vtx[0].wit.vtxinwit[0].scriptWitness.stack = [ ser_uint256(1) ]
+        block.vtx[0].wit.vtxinwit[0].scriptWitness.stack = [ser_uint256(1)]
         test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=False)
 
         # Changing the witness reserved value doesn't change the block hash
-        block.vtx[0].wit.vtxinwit[0].scriptWitness.stack = [ ser_uint256(0) ]
+        block.vtx[0].wit.vtxinwit[0].scriptWitness.stack = [ser_uint256(0)]
         test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
-
 
     def test_witness_block_size(self):
         self.log.info("Testing witness block size limit")
@@ -493,21 +554,21 @@ class SegWitTest(BitcoinTestFramework):
         # The witness program will be a bunch of OP_2DROP's, followed by OP_TRUE.
         # This should give us plenty of room to tweak the spending tx's
         # virtual size.
-        NUM_DROPS = 200 # 201 max ops per script!
+        NUM_DROPS = 200  # 201 max ops per script!
         NUM_OUTPUTS = 50
 
-        witness_program = CScript([OP_2DROP]*NUM_DROPS + [OP_TRUE])
+        witness_program = CScript([OP_2DROP] * NUM_DROPS + [OP_TRUE])
         witness_hash = uint256_from_str(sha256(witness_program))
-        scriptPubKey = CScript([OP_0, ser_uint256(witness_hash)])
+        script_pubkey = CScript([OP_0, ser_uint256(witness_hash)])
 
         prevout = COutPoint(self.utxo[0].sha256, self.utxo[0].n)
         value = self.utxo[0].nValue
 
         parent_tx = CTransaction()
         parent_tx.vin.append(CTxIn(prevout, b""))
-        child_value = int(value/NUM_OUTPUTS)
+        child_value = int(value / NUM_OUTPUTS)
         for i in range(NUM_OUTPUTS):
-            parent_tx.vout.append(CTxOut(child_value, scriptPubKey))
+            parent_tx.vout.append(CTxOut(child_value, script_pubkey))
         parent_tx.vout[0].nValue -= 50000
         assert(parent_tx.vout[0].nValue > 0)
         parent_tx.rehash()
@@ -518,17 +579,17 @@ class SegWitTest(BitcoinTestFramework):
         child_tx.vout = [CTxOut(value - 100000, CScript([OP_TRUE]))]
         for i in range(NUM_OUTPUTS):
             child_tx.wit.vtxinwit.append(CTxInWitness())
-            child_tx.wit.vtxinwit[-1].scriptWitness.stack = [b'a'*195]*(2*NUM_DROPS) + [witness_program]
+            child_tx.wit.vtxinwit[-1].scriptWitness.stack = [b'a' * 195] * (2 * NUM_DROPS) + [witness_program]
         child_tx.rehash()
         self.update_witness_block_with_transactions(block, [parent_tx, child_tx])
 
         vsize = get_virtual_size(block)
-        additional_bytes = (MAX_BLOCK_BASE_SIZE - vsize)*4
+        additional_bytes = (MAX_BLOCK_BASE_SIZE - vsize) * 4
         i = 0
         while additional_bytes > 0:
             # Add some more bytes to each input until we hit MAX_BLOCK_BASE_SIZE+1
-            extra_bytes = min(additional_bytes+1, 55)
-            block.vtx[-1].wit.vtxinwit[int(i/(2*NUM_DROPS))].scriptWitness.stack[i%(2*NUM_DROPS)] = b'a'*(195+extra_bytes)
+            extra_bytes = min(additional_bytes + 1, 55)
+            block.vtx[-1].wit.vtxinwit[int(i / (2 * NUM_DROPS))].scriptWitness.stack[i % (2 * NUM_DROPS)] = b'a' * (195 + extra_bytes)
             additional_bytes -= extra_bytes
             i += 1
 
@@ -539,13 +600,13 @@ class SegWitTest(BitcoinTestFramework):
         assert_equal(vsize, MAX_BLOCK_BASE_SIZE + 1)
         # Make sure that our test case would exceed the old max-network-message
         # limit
-        assert(len(block.serialize(True)) > 2*1024*1024)
+        assert(len(block.serialize(True)) > 2 * 1024 * 1024)
 
         test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=False)
 
         # Now resize the second transaction to make the block fit.
         cur_length = len(block.vtx[-1].wit.vtxinwit[0].scriptWitness.stack[0])
-        block.vtx[-1].wit.vtxinwit[0].scriptWitness.stack[0] = b'a'*(cur_length-1)
+        block.vtx[-1].wit.vtxinwit[0].scriptWitness.stack[0] = b'a' * (cur_length - 1)
         block.vtx[0].vout.pop()
         add_witness_commitment(block)
         block.solve()
@@ -557,7 +618,6 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue))
 
-
     # submitblock will try to add the nonce automatically, so that mining
     # software doesn't need to worry about doing so itself.
     def test_submit_block(self):
@@ -566,7 +626,7 @@ class SegWitTest(BitcoinTestFramework):
         # Try using a custom nonce and then don't supply it.
         # This shouldn't possibly work.
         add_witness_commitment(block, nonce=1)
-        block.vtx[0].wit = CTxWitness() # drop the nonce
+        block.vtx[0].wit = CTxWitness()  # drop the nonce
         block.solve()
         self.nodes[0].submitblock(bytes_to_hex_str(block.serialize(True)))
         assert(self.nodes[0].getbestblockhash() != block.hash)
@@ -594,7 +654,6 @@ class SegWitTest(BitcoinTestFramework):
         # Tip should not advance!
         assert(self.nodes[0].getbestblockhash() != block_2.hash)
 
-
     # Consensus tests of extra witness data in a transaction.
     def test_extra_witness_data(self):
         self.log.info("Testing extra witness data in tx")
@@ -605,13 +664,13 @@ class SegWitTest(BitcoinTestFramework):
 
         witness_program = CScript([OP_DROP, OP_TRUE])
         witness_hash = sha256(witness_program)
-        scriptPubKey = CScript([OP_0, witness_hash])
+        script_pubkey = CScript([OP_0, witness_hash])
 
         # First try extra witness data on a tx that doesn't require a witness
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        tx.vout.append(CTxOut(self.utxo[0].nValue-2000, scriptPubKey))
-        tx.vout.append(CTxOut(1000, CScript([OP_TRUE]))) # non-witness output
+        tx.vout.append(CTxOut(self.utxo[0].nValue - 2000, script_pubkey))
+        tx.vout.append(CTxOut(1000, CScript([OP_TRUE])))  # non-witness output
         tx.wit.vtxinwit.append(CTxInWitness())
         tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([])]
         tx.rehash()
@@ -632,12 +691,12 @@ class SegWitTest(BitcoinTestFramework):
         # Now try extra witness/signature data on an input that DOES require a
         # witness
         tx2 = CTransaction()
-        tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b"")) # witness output
-        tx2.vin.append(CTxIn(COutPoint(tx.sha256, 1), b"")) # non-witness
+        tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))  # witness output
+        tx2.vin.append(CTxIn(COutPoint(tx.sha256, 1), b""))  # non-witness
         tx2.vout.append(CTxOut(tx.vout[0].nValue, CScript([OP_TRUE])))
         tx2.wit.vtxinwit.extend([CTxInWitness(), CTxInWitness()])
-        tx2.wit.vtxinwit[0].scriptWitness.stack = [ CScript([CScriptNum(1)]), CScript([CScriptNum(1)]), witness_program ]
-        tx2.wit.vtxinwit[1].scriptWitness.stack = [ CScript([OP_TRUE]) ]
+        tx2.wit.vtxinwit[0].scriptWitness.stack = [CScript([CScriptNum(1)]), CScript([CScriptNum(1)]), witness_program]
+        tx2.wit.vtxinwit[1].scriptWitness.stack = [CScript([OP_TRUE])]
 
         block = self.build_next_block()
         self.update_witness_block_with_transactions(block, [tx2])
@@ -670,7 +729,6 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx2.sha256, 0, tx2.vout[0].nValue))
 
-
     def test_max_witness_push_length(self):
         ''' Should only allow up to 520 byte pushes in witness stack '''
         self.log.info("Testing maximum witness push size")
@@ -681,26 +739,26 @@ class SegWitTest(BitcoinTestFramework):
 
         witness_program = CScript([OP_DROP, OP_TRUE])
         witness_hash = sha256(witness_program)
-        scriptPubKey = CScript([OP_0, witness_hash])
+        script_pubkey = CScript([OP_0, witness_hash])
 
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        tx.vout.append(CTxOut(self.utxo[0].nValue-1000, scriptPubKey))
+        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, script_pubkey))
         tx.rehash()
 
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue-1000, CScript([OP_TRUE])))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE])))
         tx2.wit.vtxinwit.append(CTxInWitness())
         # First try a 521-byte stack element
-        tx2.wit.vtxinwit[0].scriptWitness.stack = [ b'a'*(MAX_SCRIPT_ELEMENT_SIZE+1), witness_program ]
+        tx2.wit.vtxinwit[0].scriptWitness.stack = [b'a' * (MAX_SCRIPT_ELEMENT_SIZE + 1), witness_program]
         tx2.rehash()
 
         self.update_witness_block_with_transactions(block, [tx, tx2])
         test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=False)
 
         # Now reduce the length of the stack element
-        tx2.wit.vtxinwit[0].scriptWitness.stack[0] = b'a'*(MAX_SCRIPT_ELEMENT_SIZE)
+        tx2.wit.vtxinwit[0].scriptWitness.stack[0] = b'a' * (MAX_SCRIPT_ELEMENT_SIZE)
 
         add_witness_commitment(block)
         block.solve()
@@ -718,23 +776,23 @@ class SegWitTest(BitcoinTestFramework):
         MAX_PROGRAM_LENGTH = 10000
 
         # This program is 19 max pushes (9937 bytes), then 64 more opcode-bytes.
-        long_witness_program = CScript([b'a'*520]*19 + [OP_DROP]*63 + [OP_TRUE])
-        assert(len(long_witness_program) == MAX_PROGRAM_LENGTH+1)
+        long_witness_program = CScript([b'a' * 520] * 19 + [OP_DROP] * 63 + [OP_TRUE])
+        assert(len(long_witness_program) == MAX_PROGRAM_LENGTH + 1)
         long_witness_hash = sha256(long_witness_program)
-        long_scriptPubKey = CScript([OP_0, long_witness_hash])
+        long_script_pubkey = CScript([OP_0, long_witness_hash])
 
         block = self.build_next_block()
 
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        tx.vout.append(CTxOut(self.utxo[0].nValue-1000, long_scriptPubKey))
+        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, long_script_pubkey))
         tx.rehash()
 
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue-1000, CScript([OP_TRUE])))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE])))
         tx2.wit.vtxinwit.append(CTxInWitness())
-        tx2.wit.vtxinwit[0].scriptWitness.stack = [b'a']*44 + [long_witness_program]
+        tx2.wit.vtxinwit[0].scriptWitness.stack = [b'a'] * 44 + [long_witness_program]
         tx2.rehash()
 
         self.update_witness_block_with_transactions(block, [tx, tx2])
@@ -742,15 +800,15 @@ class SegWitTest(BitcoinTestFramework):
         test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=False)
 
         # Try again with one less byte in the witness program
-        witness_program = CScript([b'a'*520]*19 + [OP_DROP]*62 + [OP_TRUE])
+        witness_program = CScript([b'a' * 520] * 19 + [OP_DROP] * 62 + [OP_TRUE])
         assert(len(witness_program) == MAX_PROGRAM_LENGTH)
         witness_hash = sha256(witness_program)
-        scriptPubKey = CScript([OP_0, witness_hash])
+        script_pubkey = CScript([OP_0, witness_hash])
 
-        tx.vout[0] = CTxOut(tx.vout[0].nValue, scriptPubKey)
+        tx.vout[0] = CTxOut(tx.vout[0].nValue, script_pubkey)
         tx.rehash()
         tx2.vin[0].prevout.hash = tx.sha256
-        tx2.wit.vtxinwit[0].scriptWitness.stack = [b'a']*43 + [witness_program]
+        tx2.wit.vtxinwit[0].scriptWitness.stack = [b'a'] * 43 + [witness_program]
         tx2.rehash()
         block.vtx = [block.vtx[0]]
         self.update_witness_block_with_transactions(block, [tx, tx2])
@@ -759,7 +817,6 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop()
         self.utxo.append(UTXO(tx2.sha256, 0, tx2.vout[0].nValue))
 
-
     def test_witness_input_length(self):
         ''' Ensure that vin length must match vtxinwit length '''
         self.log.info("Testing witness input length")
@@ -767,14 +824,14 @@ class SegWitTest(BitcoinTestFramework):
 
         witness_program = CScript([OP_DROP, OP_TRUE])
         witness_hash = sha256(witness_program)
-        scriptPubKey = CScript([OP_0, witness_hash])
+        script_pubkey = CScript([OP_0, witness_hash])
 
         # Create a transaction that splits our utxo into many outputs
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        nValue = self.utxo[0].nValue
+        value = self.utxo[0].nValue
         for i in range(10):
-            tx.vout.append(CTxOut(int(nValue/10), scriptPubKey))
+            tx.vout.append(CTxOut(int(value / 10), script_pubkey))
         tx.vout[0].nValue -= 1000
         assert(tx.vout[0].nValue >= 0)
 
@@ -806,7 +863,7 @@ class SegWitTest(BitcoinTestFramework):
         tx2 = BrokenCTransaction()
         for i in range(10):
             tx2.vin.append(CTxIn(COutPoint(tx.sha256, i), b""))
-        tx2.vout.append(CTxOut(nValue-3000, CScript([OP_TRUE])))
+        tx2.vout.append(CTxOut(value - 3000, CScript([OP_TRUE])))
 
         # First try using a too long vtxinwit
         for i in range(11):
@@ -828,7 +885,7 @@ class SegWitTest(BitcoinTestFramework):
         # Now make one of the intermediate witnesses be incorrect
         tx2.wit.vtxinwit.append(CTxInWitness())
         tx2.wit.vtxinwit[-1].scriptWitness.stack = [b'a', witness_program]
-        tx2.wit.vtxinwit[5].scriptWitness.stack = [ witness_program ]
+        tx2.wit.vtxinwit[5].scriptWitness.stack = [witness_program]
 
         block.vtx = [block.vtx[0]]
         self.update_witness_block_with_transactions(block, [tx2])
@@ -843,7 +900,6 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop()
         self.utxo.append(UTXO(tx2.sha256, 0, tx2.vout[0].nValue))
 
-
     def test_witness_tx_relay_before_segwit_activation(self):
         self.log.info("Testing relay of witness transactions")
         # Generate a transaction that doesn't require a witness, but send it
@@ -854,7 +910,7 @@ class SegWitTest(BitcoinTestFramework):
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
         tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))
         tx.wit.vtxinwit.append(CTxInWitness())
-        tx.wit.vtxinwit[0].scriptWitness.stack = [ b'a' ]
+        tx.wit.vtxinwit[0].scriptWitness.stack = [b'a']
         tx.rehash()
 
         tx_hash = tx.sha256
@@ -881,11 +937,10 @@ class SegWitTest(BitcoinTestFramework):
 
         # Cleanup: mine the first transaction and update utxo
         self.nodes[0].generate(1)
-        assert_equal(len(self.nodes[0].getrawmempool()),  0)
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
 
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx_hash, 0, tx_value))
-
 
     # After segwit activates, verify that mempool:
     # - rejects transactions with unnecessary/extra witnesses
@@ -901,7 +956,7 @@ class SegWitTest(BitcoinTestFramework):
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
         tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))
         tx.wit.vtxinwit.append(CTxInWitness())
-        tx.wit.vtxinwit[0].scriptWitness.stack = [ b'a' ]
+        tx.wit.vtxinwit[0].scriptWitness.stack = [b'a']
         tx.rehash()
 
         tx_hash = tx.sha256
@@ -918,10 +973,10 @@ class SegWitTest(BitcoinTestFramework):
         # Now try to add extra witness data to a valid witness tx.
         witness_program = CScript([OP_TRUE])
         witness_hash = sha256(witness_program)
-        scriptPubKey = CScript([OP_0, witness_hash])
+        script_pubkey = CScript([OP_0, witness_hash])
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx_hash, 0), b""))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue-1000, scriptPubKey))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, script_pubkey))
         tx2.rehash()
 
         tx3 = CTransaction()
@@ -931,8 +986,8 @@ class SegWitTest(BitcoinTestFramework):
         # Add too-large for IsStandard witness and check that it does not enter reject filter
         p2sh_program = CScript([OP_TRUE])
         p2sh_pubkey = hash160(p2sh_program)
-        witness_program2 = CScript([b'a'*400000])
-        tx3.vout.append(CTxOut(tx2.vout[0].nValue-1000, CScript([OP_HASH160, p2sh_pubkey, OP_EQUAL])))
+        witness_program2 = CScript([b'a' * 400000])
+        tx3.vout.append(CTxOut(tx2.vout[0].nValue - 1000, CScript([OP_HASH160, p2sh_pubkey, OP_EQUAL])))
         tx3.wit.vtxinwit[0].scriptWitness.stack = [witness_program2]
         tx3.rehash()
 
@@ -944,17 +999,17 @@ class SegWitTest(BitcoinTestFramework):
 
         # Remove witness stuffing, instead add extra witness push on stack
         tx3.vout[0] = CTxOut(tx2.vout[0].nValue - 1000, CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE]))
-        tx3.wit.vtxinwit[0].scriptWitness.stack = [CScript([CScriptNum(1)]), witness_program ]
+        tx3.wit.vtxinwit[0].scriptWitness.stack = [CScript([CScriptNum(1)]), witness_program]
         tx3.rehash()
 
         test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx2, with_witness=True, accepted=True)
         test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx3, with_witness=True, accepted=False)
 
         # Get rid of the extra witness, and verify acceptance.
-        tx3.wit.vtxinwit[0].scriptWitness.stack = [ witness_program ]
+        tx3.wit.vtxinwit[0].scriptWitness.stack = [witness_program]
         # Also check that old_node gets a tx announcement, even though this is
         # a witness transaction.
-        self.old_node.wait_for_inv([CInv(1, tx2.sha256)]) # wait until tx2 was inv'ed
+        self.old_node.wait_for_inv([CInv(1, tx2.sha256)])  # wait until tx2 was inv'ed
         test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx3, with_witness=True, accepted=True)
         self.old_node.wait_for_inv([CInv(1, tx3.sha256)])
 
@@ -963,7 +1018,7 @@ class SegWitTest(BitcoinTestFramework):
         raw_tx = self.nodes[0].getrawtransaction(tx3.hash, 1)
         assert_equal(int(raw_tx["hash"], 16), tx3.calc_sha256(True))
         assert_equal(raw_tx["size"], len(tx3.serialize_with_witness()))
-        weight = len(tx3.serialize_with_witness()) + 3*len(tx3.serialize_without_witness())
+        weight = len(tx3.serialize_with_witness()) + 3 * len(tx3.serialize_without_witness())
         vsize = math.ceil(weight / 4)
         assert_equal(raw_tx["vsize"], vsize)
         assert_equal(raw_tx["weight"], weight)
@@ -973,11 +1028,10 @@ class SegWitTest(BitcoinTestFramework):
 
         # Cleanup: mine the transactions and update utxo for next test
         self.nodes[0].generate(1)
-        assert_equal(len(self.nodes[0].getrawmempool()),  0)
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
 
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
-
 
     # Test that block requests to NODE_WITNESS peer are with MSG_WITNESS_FLAG
     # This is true regardless of segwit activation.
@@ -985,7 +1039,7 @@ class SegWitTest(BitcoinTestFramework):
     def test_block_relay(self, segwit_activated):
         self.log.info("Testing block relay")
 
-        blocktype = 2|MSG_WITNESS_FLAG
+        blocktype = 2 | MSG_WITNESS_FLAG
 
         # test_node has set NODE_WITNESS, so all getdata requests should be for
         # witness blocks.
@@ -998,14 +1052,14 @@ class SegWitTest(BitcoinTestFramework):
         assert(self.test_node.last_message["getdata"].inv[0].type == blocktype)
         test_witness_block(self.nodes[0].rpc, self.test_node, block1, True)
 
-        block2 = self.build_next_block(nVersion=4)
+        block2 = self.build_next_block(version=4)
         block2.solve()
 
         self.test_node.announce_block_and_wait_for_getdata(block2, use_header=True)
         assert(self.test_node.last_message["getdata"].inv[0].type == blocktype)
         test_witness_block(self.nodes[0].rpc, self.test_node, block2, True)
 
-        block3 = self.build_next_block(nVersion=(VB_TOP_BITS | (1<<15)))
+        block3 = self.build_next_block(version=(VB_TOP_BITS | (1 << 15)))
         block3.solve()
         self.test_node.announce_block_and_wait_for_getdata(block3, use_header=True)
         assert(self.test_node.last_message["getdata"].inv[0].type == blocktype)
@@ -1013,13 +1067,13 @@ class SegWitTest(BitcoinTestFramework):
 
         # Check that we can getdata for witness blocks or regular blocks,
         # and the right thing happens.
-        if segwit_activated == False:
+        if not segwit_activated:
             # Before activation, we should be able to request old blocks with
             # or without witness, and they should be the same.
             chain_height = self.nodes[0].getblockcount()
             # Pick 10 random blocks on main chain, and verify that getdata's
             # for MSG_BLOCK, MSG_WITNESS_BLOCK, and rpc getblock() are equal.
-            all_heights = list(range(chain_height+1))
+            all_heights = list(range(chain_height + 1))
             random.shuffle(all_heights)
             all_heights = all_heights[0:10]
             for height in all_heights:
@@ -1027,7 +1081,7 @@ class SegWitTest(BitcoinTestFramework):
                 rpc_block = self.nodes[0].getblock(block_hash, False)
                 block_hash = int(block_hash, 16)
                 block = self.test_node.request_block(block_hash, 2)
-                wit_block = self.test_node.request_block(block_hash, 2|MSG_WITNESS_FLAG)
+                wit_block = self.test_node.request_block(block_hash, 2 | MSG_WITNESS_FLAG)
                 assert_equal(block.serialize(True), wit_block.serialize(True))
                 assert_equal(block.serialize(), hex_str_to_bytes(rpc_block))
         else:
@@ -1043,7 +1097,7 @@ class SegWitTest(BitcoinTestFramework):
             # Now try to retrieve it...
             rpc_block = self.nodes[0].getblock(block.hash, False)
             non_wit_block = self.test_node.request_block(block.sha256, 2)
-            wit_block = self.test_node.request_block(block.sha256, 2|MSG_WITNESS_FLAG)
+            wit_block = self.test_node.request_block(block.sha256, 2 | MSG_WITNESS_FLAG)
             assert_equal(wit_block.serialize(True), hex_str_to_bytes(rpc_block))
             assert_equal(wit_block.serialize(False), non_wit_block.serialize())
             assert_equal(wit_block.serialize(True), block.serialize(True))
@@ -1052,11 +1106,11 @@ class SegWitTest(BitcoinTestFramework):
             rpc_details = self.nodes[0].getblock(block.hash, True)
             assert_equal(rpc_details["size"], len(block.serialize(True)))
             assert_equal(rpc_details["strippedsize"], len(block.serialize(False)))
-            weight = 3*len(block.serialize(False)) + len(block.serialize(True))
+            weight = 3 * len(block.serialize(False)) + len(block.serialize(True))
             assert_equal(rpc_details["weight"], weight)
 
             # Upgraded node should not ask for blocks from unupgraded
-            block4 = self.build_next_block(nVersion=4)
+            block4 = self.build_next_block(version=4)
             block4.solve()
             self.old_node.getdataset = set()
 
@@ -1069,7 +1123,7 @@ class SegWitTest(BitcoinTestFramework):
             # Since 0.14, inv's will only be responded to with a getheaders, so send a header
             # to announce this block.
             msg = msg_headers()
-            msg.headers = [ CBlockHeader(block4) ]
+            msg.headers = [CBlockHeader(block4)]
             self.old_node.send_message(msg)
             self.old_node.announce_tx_and_wait_for_getdata(block4.vtx[0])
             assert(block4.sha256 not in self.old_node.getdataset)
@@ -1081,15 +1135,15 @@ class SegWitTest(BitcoinTestFramework):
 
         witness_program = CScript([OP_TRUE])
         witness_hash = sha256(witness_program)
-        scriptPubKey = CScript([OP_0, witness_hash])
+        script_pubkey = CScript([OP_0, witness_hash])
 
         p2sh_pubkey = hash160(witness_program)
-        p2sh_scriptPubKey = CScript([OP_HASH160, p2sh_pubkey, OP_EQUAL])
+        p2sh_script_pubkey = CScript([OP_HASH160, p2sh_pubkey, OP_EQUAL])
 
         # First prepare a p2sh output (so that spending it will pass standardness)
         p2sh_tx = CTransaction()
         p2sh_tx.vin = [CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b"")]
-        p2sh_tx.vout = [CTxOut(self.utxo[0].nValue-1000, p2sh_scriptPubKey)]
+        p2sh_tx.vout = [CTxOut(self.utxo[0].nValue - 1000, p2sh_script_pubkey)]
         p2sh_tx.rehash()
 
         # Mine it on test_node to create the confirmed output.
@@ -1101,8 +1155,8 @@ class SegWitTest(BitcoinTestFramework):
         # Start by creating a transaction with two outputs.
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(p2sh_tx.sha256, 0), CScript([witness_program]))]
-        tx.vout = [CTxOut(p2sh_tx.vout[0].nValue-10000, scriptPubKey)]
-        tx.vout.append(CTxOut(8000, scriptPubKey)) # Might burn this later
+        tx.vout = [CTxOut(p2sh_tx.vout[0].nValue - 10000, script_pubkey)]
+        tx.vout.append(CTxOut(8000, script_pubkey))  # Might burn this later
         tx.vin[0].nSequence = BIP125_SEQUENCE_NUMBER  # Just to have the option to bump this tx from the mempool
         tx.rehash()
 
@@ -1111,11 +1165,11 @@ class SegWitTest(BitcoinTestFramework):
         test_transaction_acceptance(self.nodes[1].rpc, self.std_node, tx, with_witness=True, accepted=True)
 
         # Now create something that looks like a P2PKH output. This won't be spendable.
-        scriptPubKey = CScript([OP_0, hash160(witness_hash)])
+        script_pubkey = CScript([OP_0, hash160(witness_hash)])
         tx2 = CTransaction()
         # tx was accepted, so we spend the second output.
         tx2.vin = [CTxIn(COutPoint(tx.sha256, 1), b"")]
-        tx2.vout = [CTxOut(7000, scriptPubKey)]
+        tx2.vout = [CTxOut(7000, script_pubkey)]
         tx2.wit.vtxinwit.append(CTxInWitness())
         tx2.wit.vtxinwit[0].scriptWitness.stack = [witness_program]
         tx2.rehash()
@@ -1150,25 +1204,24 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
         assert_equal(len(self.nodes[1].getrawmempool()), 0)
 
-
     # Verify that future segwit upgraded transactions are non-standard,
     # but valid in blocks. Can run this before and after segwit activation.
     def test_segwit_versions(self):
         self.log.info("Testing standardness/consensus for segwit versions (0-16)")
         assert(len(self.utxo))
-        NUM_TESTS = 17 # will test OP_0, OP1, ..., OP_16
-        if (len(self.utxo) < NUM_TESTS):
+        num_tests = 17  # will test OP_0, OP1, ..., OP_16
+        if (len(self.utxo) < num_tests):
             tx = CTransaction()
             tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-            split_value = (self.utxo[0].nValue - 4000) // NUM_TESTS
-            for i in range(NUM_TESTS):
+            split_value = (self.utxo[0].nValue - 4000) // num_tests
+            for i in range(num_tests):
                 tx.vout.append(CTxOut(split_value, CScript([OP_TRUE])))
             tx.rehash()
             block = self.build_next_block()
             self.update_witness_block_with_transactions(block, [tx])
             test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
             self.utxo.pop(0)
-            for i in range(NUM_TESTS):
+            for i in range(num_tests):
                 self.utxo.append(UTXO(tx.sha256, i, split_value))
 
         sync_blocks(self.nodes)
@@ -1178,36 +1231,36 @@ class SegWitTest(BitcoinTestFramework):
         witness_program = CScript([OP_TRUE])
         witness_hash = sha256(witness_program)
         assert_equal(len(self.nodes[1].getrawmempool()), 0)
-        for version in list(range(OP_1, OP_16+1)) + [OP_0]:
+        for version in list(range(OP_1, OP_16 + 1)) + [OP_0]:
             count += 1
-            # First try to spend to a future version segwit scriptPubKey.
-            scriptPubKey = CScript([CScriptOp(version), witness_hash])
+            # First try to spend to a future version segwit script_pubkey.
+            script_pubkey = CScript([CScriptOp(version), witness_hash])
             tx.vin = [CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b"")]
-            tx.vout = [CTxOut(self.utxo[0].nValue-1000, scriptPubKey)]
+            tx.vout = [CTxOut(self.utxo[0].nValue - 1000, script_pubkey)]
             tx.rehash()
             test_transaction_acceptance(self.nodes[1].rpc, self.std_node, tx, with_witness=True, accepted=False)
             test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx, with_witness=True, accepted=True)
             self.utxo.pop(0)
             temp_utxo.append(UTXO(tx.sha256, 0, tx.vout[0].nValue))
 
-        self.nodes[0].generate(1) # Mine all the transactions
+        self.nodes[0].generate(1)  # Mine all the transactions
         sync_blocks(self.nodes)
         assert(len(self.nodes[0].getrawmempool()) == 0)
 
         # Finally, verify that version 0 -> version 1 transactions
         # are non-standard
-        scriptPubKey = CScript([CScriptOp(OP_1), witness_hash])
+        script_pubkey = CScript([CScriptOp(OP_1), witness_hash])
         tx2 = CTransaction()
         tx2.vin = [CTxIn(COutPoint(tx.sha256, 0), b"")]
-        tx2.vout = [CTxOut(tx.vout[0].nValue-1000, scriptPubKey)]
+        tx2.vout = [CTxOut(tx.vout[0].nValue - 1000, script_pubkey)]
         tx2.wit.vtxinwit.append(CTxInWitness())
-        tx2.wit.vtxinwit[0].scriptWitness.stack = [ witness_program ]
+        tx2.wit.vtxinwit[0].scriptWitness.stack = [witness_program]
         tx2.rehash()
         # Gets accepted to test_node, because standardness of outputs isn't
         # checked with fRequireStandard
         test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx2, with_witness=True, accepted=True)
         test_transaction_acceptance(self.nodes[1].rpc, self.std_node, tx2, with_witness=True, accepted=False)
-        temp_utxo.pop() # last entry in temp_utxo was the output we just spent
+        temp_utxo.pop()  # last entry in temp_utxo was the output we just spent
         temp_utxo.append(UTXO(tx2.sha256, 0, tx2.vout[0].nValue))
 
         # Spend everything in temp_utxo back to an OP_TRUE output.
@@ -1236,15 +1289,14 @@ class SegWitTest(BitcoinTestFramework):
         # Add utxo to our list
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
 
-
     def test_premature_coinbase_witness_spend(self):
         self.log.info("Testing premature coinbase witness spend")
         block = self.build_next_block()
         # Change the output of the block to be a witness output.
         witness_program = CScript([OP_TRUE])
         witness_hash = sha256(witness_program)
-        scriptPubKey = CScript([OP_0, witness_hash])
-        block.vtx[0].vout[0].scriptPubKey = scriptPubKey
+        script_pubkey = CScript([OP_0, witness_hash])
+        block.vtx[0].vout[0].scriptPubKey = script_pubkey
         # This next line will rehash the coinbase and update the merkle
         # root, and solve.
         self.update_witness_block_with_transactions(block, [])
@@ -1254,7 +1306,7 @@ class SegWitTest(BitcoinTestFramework):
         spend_tx.vin = [CTxIn(COutPoint(block.vtx[0].sha256, 0), b"")]
         spend_tx.vout = [CTxOut(block.vtx[0].vout[0].nValue, witness_program)]
         spend_tx.wit.vtxinwit.append(CTxInWitness())
-        spend_tx.wit.vtxinwit[0].scriptWitness.stack = [ witness_program ]
+        spend_tx.wit.vtxinwit[0].scriptWitness.stack = [witness_program]
         spend_tx.rehash()
 
         # Now test a premature spend.
@@ -1271,7 +1323,6 @@ class SegWitTest(BitcoinTestFramework):
         test_witness_block(self.nodes[0].rpc, self.test_node, block2, accepted=True)
         sync_blocks(self.nodes)
 
-
     def test_signature_version_1(self):
         self.log.info("Testing segwit signature hash version 1")
         key = CECKey()
@@ -1280,13 +1331,13 @@ class SegWitTest(BitcoinTestFramework):
 
         witness_program = CScript([pubkey, CScriptOp(OP_CHECKSIG)])
         witness_hash = sha256(witness_program)
-        scriptPubKey = CScript([OP_0, witness_hash])
+        script_pubkey = CScript([OP_0, witness_hash])
 
         # First create a witness output for use in the tests.
         assert(len(self.utxo))
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        tx.vout.append(CTxOut(self.utxo[0].nValue-1000, scriptPubKey))
+        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, script_pubkey))
         tx.rehash()
 
         test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx, with_witness=True, accepted=True)
@@ -1299,27 +1350,27 @@ class SegWitTest(BitcoinTestFramework):
 
         # Test each hashtype
         prev_utxo = UTXO(tx.sha256, 0, tx.vout[0].nValue)
-        for sigflag in [ 0, SIGHASH_ANYONECANPAY ]:
+        for sigflag in [0, SIGHASH_ANYONECANPAY]:
             for hashtype in [SIGHASH_ALL, SIGHASH_NONE, SIGHASH_SINGLE]:
                 hashtype |= sigflag
                 block = self.build_next_block()
                 tx = CTransaction()
                 tx.vin.append(CTxIn(COutPoint(prev_utxo.sha256, prev_utxo.n), b""))
-                tx.vout.append(CTxOut(prev_utxo.nValue - 1000, scriptPubKey))
+                tx.vout.append(CTxOut(prev_utxo.nValue - 1000, script_pubkey))
                 tx.wit.vtxinwit.append(CTxInWitness())
                 # Too-large input value
-                sign_P2PK_witness_input(witness_program, tx, 0, hashtype, prev_utxo.nValue+1, key)
+                sign_p2pk_witness_input(witness_program, tx, 0, hashtype, prev_utxo.nValue + 1, key)
                 self.update_witness_block_with_transactions(block, [tx])
                 test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=False)
 
                 # Too-small input value
-                sign_P2PK_witness_input(witness_program, tx, 0, hashtype, prev_utxo.nValue-1, key)
-                block.vtx.pop() # remove last tx
+                sign_p2pk_witness_input(witness_program, tx, 0, hashtype, prev_utxo.nValue - 1, key)
+                block.vtx.pop()  # remove last tx
                 self.update_witness_block_with_transactions(block, [tx])
                 test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=False)
 
                 # Now try correct value
-                sign_P2PK_witness_input(witness_program, tx, 0, hashtype, prev_utxo.nValue, key)
+                sign_p2pk_witness_input(witness_program, tx, 0, hashtype, prev_utxo.nValue, key)
                 block.vtx.pop()
                 self.update_witness_block_with_transactions(block, [tx])
                 test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
@@ -1329,19 +1380,19 @@ class SegWitTest(BitcoinTestFramework):
         # Test combinations of signature hashes.
         # Split the utxo into a lot of outputs.
         # Randomly choose up to 10 to spend, sign with different hashtypes, and
-        # output to a random number of outputs.  Repeat NUM_TESTS times.
+        # output to a random number of outputs.  Repeat num_tests times.
         # Ensure that we've tested a situation where we use SIGHASH_SINGLE with
         # an input index > number of outputs.
-        NUM_TESTS = 500
+        num_tests = 500
         temp_utxos = []
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(prev_utxo.sha256, prev_utxo.n), b""))
-        split_value = prev_utxo.nValue // NUM_TESTS
-        for i in range(NUM_TESTS):
-            tx.vout.append(CTxOut(split_value, scriptPubKey))
+        split_value = prev_utxo.nValue // num_tests
+        for i in range(num_tests):
+            tx.vout.append(CTxOut(split_value, script_pubkey))
         tx.wit.vtxinwit.append(CTxInWitness())
-        sign_P2PK_witness_input(witness_program, tx, 0, SIGHASH_ALL, prev_utxo.nValue, key)
-        for i in range(NUM_TESTS):
+        sign_p2pk_witness_input(witness_program, tx, 0, SIGHASH_ALL, prev_utxo.nValue, key)
+        for i in range(num_tests):
             temp_utxos.append(UTXO(tx.sha256, i, split_value))
 
         block = self.build_next_block()
@@ -1350,7 +1401,7 @@ class SegWitTest(BitcoinTestFramework):
 
         block = self.build_next_block()
         used_sighash_single_out_of_bounds = False
-        for i in range(NUM_TESTS):
+        for i in range(num_tests):
             # Ping regularly to keep the connection alive
             if (not i % 100):
                 self.test_node.sync_with_ping()
@@ -1368,14 +1419,14 @@ class SegWitTest(BitcoinTestFramework):
                 total_value += temp_utxos[i].nValue
             split_value = total_value // num_outputs
             for i in range(num_outputs):
-                tx.vout.append(CTxOut(split_value, scriptPubKey))
+                tx.vout.append(CTxOut(split_value, script_pubkey))
             for i in range(num_inputs):
                 # Now try to sign each input, using a random hashtype.
                 anyonecanpay = 0
                 if random.randint(0, 1):
                     anyonecanpay = SIGHASH_ANYONECANPAY
                 hashtype = random.randint(1, 3) | anyonecanpay
-                sign_P2PK_witness_input(witness_program, tx, i, hashtype, temp_utxos[i].nValue, key)
+                sign_p2pk_witness_input(witness_program, tx, i, hashtype, temp_utxos[i].nValue, key)
                 if (hashtype == SIGHASH_SINGLE and i >= num_outputs):
                     used_sighash_single_out_of_bounds = True
             tx.rehash()
@@ -1400,19 +1451,19 @@ class SegWitTest(BitcoinTestFramework):
 
         # Now test witness version 0 P2PKH transactions
         pubkeyhash = hash160(pubkey)
-        scriptPKH = CScript([OP_0, pubkeyhash])
+        script_pkh = CScript([OP_0, pubkeyhash])
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(temp_utxos[0].sha256, temp_utxos[0].n), b""))
-        tx.vout.append(CTxOut(temp_utxos[0].nValue, scriptPKH))
+        tx.vout.append(CTxOut(temp_utxos[0].nValue, script_pkh))
         tx.wit.vtxinwit.append(CTxInWitness())
-        sign_P2PK_witness_input(witness_program, tx, 0, SIGHASH_ALL, temp_utxos[0].nValue, key)
+        sign_p2pk_witness_input(witness_program, tx, 0, SIGHASH_ALL, temp_utxos[0].nValue, key)
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
         tx2.vout.append(CTxOut(tx.vout[0].nValue, CScript([OP_TRUE])))
 
-        script = GetP2PKHScript(pubkeyhash)
+        script = get_p2pkh_script(pubkeyhash)
         sig_hash = SegwitVersion1SignatureHash(script, tx2, 0, SIGHASH_ALL, tx.vout[0].nValue)
-        signature = key.sign(sig_hash) + b'\x01' # 0x1 is SIGHASH_ALL
+        signature = key.sign(sig_hash) + b'\x01'  # 0x1 is SIGHASH_ALL
 
         # Check that we can't have a scriptSig
         tx2.vin[0].scriptSig = CScript([signature, pubkey])
@@ -1445,7 +1496,7 @@ class SegWitTest(BitcoinTestFramework):
             # the signatures as we go.
             tx.vin.append(CTxIn(COutPoint(i.sha256, i.n), b""))
             tx.wit.vtxinwit.append(CTxInWitness())
-            sign_P2PK_witness_input(witness_program, tx, index, SIGHASH_ALL|SIGHASH_ANYONECANPAY, i.nValue, key)
+            sign_p2pk_witness_input(witness_program, tx, index, SIGHASH_ALL | SIGHASH_ANYONECANPAY, i.nValue, key)
             index += 1
         block = self.build_next_block()
         self.update_witness_block_with_transactions(block, [tx])
@@ -1453,7 +1504,6 @@ class SegWitTest(BitcoinTestFramework):
 
         for i in range(len(tx.vout)):
             self.utxo.append(UTXO(tx.sha256, i, tx.vout[i].nValue))
-
 
     # Test P2SH wrapped witness programs.
     def test_p2sh_witness(self, segwit_activated):
@@ -1466,13 +1516,13 @@ class SegWitTest(BitcoinTestFramework):
         witness_hash = sha256(witness_program)
         p2wsh_pubkey = CScript([OP_0, witness_hash])
         p2sh_witness_hash = hash160(p2wsh_pubkey)
-        scriptPubKey = CScript([OP_HASH160, p2sh_witness_hash, OP_EQUAL])
-        scriptSig = CScript([p2wsh_pubkey]) # a push of the redeem script
+        script_pubkey = CScript([OP_HASH160, p2sh_witness_hash, OP_EQUAL])
+        script_sig = CScript([p2wsh_pubkey])  # a push of the redeem script
 
         # Fund the P2SH output
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        tx.vout.append(CTxOut(self.utxo[0].nValue-1000, scriptPubKey))
+        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, script_pubkey))
         tx.rehash()
 
         # Verify mempool acceptance and block validity
@@ -1484,8 +1534,8 @@ class SegWitTest(BitcoinTestFramework):
 
         # Now test attempts to spend the output.
         spend_tx = CTransaction()
-        spend_tx.vin.append(CTxIn(COutPoint(tx.sha256, 0), scriptSig))
-        spend_tx.vout.append(CTxOut(tx.vout[0].nValue-1000, CScript([OP_TRUE])))
+        spend_tx.vin.append(CTxIn(COutPoint(tx.sha256, 0), script_sig))
+        spend_tx.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE])))
         spend_tx.rehash()
 
         # This transaction should not be accepted into the mempool pre- or
@@ -1495,17 +1545,17 @@ class SegWitTest(BitcoinTestFramework):
         # segwit-aware would also reject this for failing CLEANSTACK.
         test_transaction_acceptance(self.nodes[0].rpc, self.test_node, spend_tx, with_witness=False, accepted=False)
 
-        # Try to put the witness script in the scriptSig, should also fail.
-        spend_tx.vin[0].scriptSig = CScript([p2wsh_pubkey, b'a'])
+        # Try to put the witness script in the script_sig, should also fail.
+        spend_tx.vin[0].script_sig = CScript([p2wsh_pubkey, b'a'])
         spend_tx.rehash()
         test_transaction_acceptance(self.nodes[0].rpc, self.test_node, spend_tx, with_witness=False, accepted=False)
 
         # Now put the witness script in the witness, should succeed after
         # segwit activates.
-        spend_tx.vin[0].scriptSig = scriptSig
+        spend_tx.vin[0].scriptSig = script_sig
         spend_tx.rehash()
         spend_tx.wit.vtxinwit.append(CTxInWitness())
-        spend_tx.wit.vtxinwit[0].scriptWitness.stack = [ b'a', witness_program ]
+        spend_tx.wit.vtxinwit[0].scriptWitness.stack = [b'a', witness_program]
 
         # Verify mempool acceptance
         test_transaction_acceptance(self.nodes[0].rpc, self.test_node, spend_tx, with_witness=True, accepted=segwit_activated)
@@ -1533,7 +1583,7 @@ class SegWitTest(BitcoinTestFramework):
     def test_upgrade_after_activation(self, node_id):
         self.log.info("Testing software upgrade after softfork activation")
 
-        assert(node_id != 0) # node0 is assumed to be a segwit-active bitcoind
+        assert(node_id != 0)  # node0 is assumed to be a segwit-active bitcoind
 
         # Make sure the nodes are all up
         sync_blocks(self.nodes)
@@ -1556,7 +1606,6 @@ class SegWitTest(BitcoinTestFramework):
             assert_equal(self.nodes[0].getblock(block_hash), self.nodes[node_id].getblock(block_hash))
             height -= 1
 
-
     def test_witness_sigops(self):
         '''Ensure sigop counting is correct inside witnesses.'''
         self.log.info("Testing sigops limit")
@@ -1564,11 +1613,11 @@ class SegWitTest(BitcoinTestFramework):
         assert(len(self.utxo))
 
         # Keep this under MAX_OPS_PER_SCRIPT (201)
-        witness_program = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKMULTISIG]*5 + [OP_CHECKSIG]*193 + [OP_ENDIF])
+        witness_program = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKMULTISIG] * 5 + [OP_CHECKSIG] * 193 + [OP_ENDIF])
         witness_hash = sha256(witness_program)
-        scriptPubKey = CScript([OP_0, witness_hash])
+        script_pubkey = CScript([OP_0, witness_hash])
 
-        sigops_per_script = 20*5 + 193*1
+        sigops_per_script = 20 * 5 + 193 * 1
         # We'll produce 2 extra outputs, one with a program that would take us
         # over max sig ops, and one with a program that would exactly reach max
         # sig ops
@@ -1576,29 +1625,29 @@ class SegWitTest(BitcoinTestFramework):
         extra_sigops_available = MAX_SIGOP_COST % sigops_per_script
 
         # We chose the number of checkmultisigs/checksigs to make this work:
-        assert(extra_sigops_available < 100) # steer clear of MAX_OPS_PER_SCRIPT
+        assert(extra_sigops_available < 100)  # steer clear of MAX_OPS_PER_SCRIPT
 
         # This script, when spent with the first
         # N(=MAX_SIGOP_COST//sigops_per_script) outputs of our transaction,
         # would push us just over the block sigop limit.
-        witness_program_toomany = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKSIG]*(extra_sigops_available + 1) + [OP_ENDIF])
+        witness_program_toomany = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKSIG] * (extra_sigops_available + 1) + [OP_ENDIF])
         witness_hash_toomany = sha256(witness_program_toomany)
-        scriptPubKey_toomany = CScript([OP_0, witness_hash_toomany])
+        script_pubkey_toomany = CScript([OP_0, witness_hash_toomany])
 
         # If we spend this script instead, we would exactly reach our sigop
         # limit (for witness sigops).
-        witness_program_justright = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKSIG]*(extra_sigops_available) + [OP_ENDIF])
+        witness_program_justright = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKSIG] * (extra_sigops_available) + [OP_ENDIF])
         witness_hash_justright = sha256(witness_program_justright)
-        scriptPubKey_justright = CScript([OP_0, witness_hash_justright])
+        script_pubkey_justright = CScript([OP_0, witness_hash_justright])
 
         # First split our available utxo into a bunch of outputs
         split_value = self.utxo[0].nValue // outputs
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
         for i in range(outputs):
-            tx.vout.append(CTxOut(split_value, scriptPubKey))
-        tx.vout[-2].scriptPubKey = scriptPubKey_toomany
-        tx.vout[-1].scriptPubKey = scriptPubKey_justright
+            tx.vout.append(CTxOut(split_value, script_pubkey))
+        tx.vout[-2].scriptPubKey = script_pubkey_toomany
+        tx.vout[-1].scriptPubKey = script_pubkey_justright
         tx.rehash()
 
         block_1 = self.build_next_block()
@@ -1609,12 +1658,12 @@ class SegWitTest(BitcoinTestFramework):
         # If we try to spend the first n-1 outputs from tx, that should be
         # too many sigops.
         total_value = 0
-        for i in range(outputs-1):
+        for i in range(outputs - 1):
             tx2.vin.append(CTxIn(COutPoint(tx.sha256, i), b""))
             tx2.wit.vtxinwit.append(CTxInWitness())
-            tx2.wit.vtxinwit[-1].scriptWitness.stack = [ witness_program ]
+            tx2.wit.vtxinwit[-1].scriptWitness.stack = [witness_program]
             total_value += tx.vout[i].nValue
-        tx2.wit.vtxinwit[-1].scriptWitness.stack = [ witness_program_toomany ]
+        tx2.wit.vtxinwit[-1].scriptWitness.stack = [witness_program_toomany]
         tx2.vout.append(CTxOut(total_value, CScript([OP_TRUE])))
         tx2.rehash()
 
@@ -1625,8 +1674,8 @@ class SegWitTest(BitcoinTestFramework):
         # Try dropping the last input in tx2, and add an output that has
         # too many sigops (contributing to legacy sigop count).
         checksig_count = (extra_sigops_available // 4) + 1
-        scriptPubKey_checksigs = CScript([OP_CHECKSIG]*checksig_count)
-        tx2.vout.append(CTxOut(0, scriptPubKey_checksigs))
+        script_pubkey_checksigs = CScript([OP_CHECKSIG] * checksig_count)
+        tx2.vout.append(CTxOut(0, script_pubkey_checksigs))
         tx2.vin.pop()
         tx2.wit.vtxinwit.pop()
         tx2.vout[0].nValue -= tx.vout[-2].nValue
@@ -1637,7 +1686,7 @@ class SegWitTest(BitcoinTestFramework):
 
         # If we drop the last checksig in this output, the tx should succeed.
         block_4 = self.build_next_block()
-        tx2.vout[-1].scriptPubKey = CScript([OP_CHECKSIG]*(checksig_count-1))
+        tx2.vout[-1].scriptPubKey = CScript([OP_CHECKSIG] * (checksig_count - 1))
         tx2.rehash()
         self.update_witness_block_with_transactions(block_4, [tx2])
         test_witness_block(self.nodes[0].rpc, self.test_node, block_4, accepted=True)
@@ -1651,9 +1700,9 @@ class SegWitTest(BitcoinTestFramework):
         # output of tx
         block_5 = self.build_next_block()
         tx2.vout.pop()
-        tx2.vin.append(CTxIn(COutPoint(tx.sha256, outputs-1), b""))
+        tx2.vin.append(CTxIn(COutPoint(tx.sha256, outputs - 1), b""))
         tx2.wit.vtxinwit.append(CTxInWitness())
-        tx2.wit.vtxinwit[-1].scriptWitness.stack = [ witness_program_justright ]
+        tx2.wit.vtxinwit[-1].scriptWitness.stack = [witness_program_justright]
         tx2.rehash()
         self.update_witness_block_with_transactions(block_5, [tx2])
         test_witness_block(self.nodes[0].rpc, self.test_node, block_5, accepted=True)
@@ -1679,11 +1728,11 @@ class SegWitTest(BitcoinTestFramework):
         txid = int(self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1), 16)
         # Using mocktime lets us avoid sleep()
         sync_mempools(self.nodes)
-        self.nodes[0].setmocktime(int(time.time())+10)
-        self.nodes[2].setmocktime(int(time.time())+10)
+        self.nodes[0].setmocktime(int(time.time()) + 10)
+        self.nodes[2].setmocktime(int(time.time()) + 10)
 
         for node in [self.nodes[0], self.nodes[2]]:
-            gbt_results = node.getblocktemplate({"rules" : ["segwit"]})
+            gbt_results = node.getblocktemplate({"rules": ["segwit"]})
             block_version = gbt_results['version']
             if node == self.nodes[2]:
                 # If this is a non-segwit node, we should still not get a witness
@@ -1717,7 +1766,7 @@ class SegWitTest(BitcoinTestFramework):
         key.set_secretbytes(b"9")
         key.set_compressed(False)
         pubkey = CPubKey(key.get_pubkey())
-        assert_equal(len(pubkey), 65) # This should be an uncompressed pubkey
+        assert_equal(len(pubkey), 65)  # This should be an uncompressed pubkey
 
         assert(len(self.utxo) > 0)
         utxo = self.utxo.pop(0)
@@ -1725,10 +1774,10 @@ class SegWitTest(BitcoinTestFramework):
         # Test 1: P2WPKH
         # First create a P2WPKH output that uses an uncompressed pubkey
         pubkeyhash = hash160(pubkey)
-        scriptPKH = CScript([OP_0, pubkeyhash])
+        script_pkh = CScript([OP_0, pubkeyhash])
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(utxo.sha256, utxo.n), b""))
-        tx.vout.append(CTxOut(utxo.nValue-1000, scriptPKH))
+        tx.vout.append(CTxOut(utxo.nValue - 1000, script_pkh))
         tx.rehash()
 
         # Confirm it in a block.
@@ -1740,16 +1789,16 @@ class SegWitTest(BitcoinTestFramework):
         # use in the next test.
         witness_program = CScript([pubkey, CScriptOp(OP_CHECKSIG)])
         witness_hash = sha256(witness_program)
-        scriptWSH = CScript([OP_0, witness_hash])
+        script_wsh = CScript([OP_0, witness_hash])
 
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue-1000, scriptWSH))
-        script = GetP2PKHScript(pubkeyhash)
+        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, script_wsh))
+        script = get_p2pkh_script(pubkeyhash)
         sig_hash = SegwitVersion1SignatureHash(script, tx2, 0, SIGHASH_ALL, tx.vout[0].nValue)
-        signature = key.sign(sig_hash) + b'\x01' # 0x1 is SIGHASH_ALL
+        signature = key.sign(sig_hash) + b'\x01'  # 0x1 is SIGHASH_ALL
         tx2.wit.vtxinwit.append(CTxInWitness())
-        tx2.wit.vtxinwit[0].scriptWitness.stack = [ signature, pubkey ]
+        tx2.wit.vtxinwit[0].scriptWitness.stack = [signature, pubkey]
         tx2.rehash()
 
         # Should fail policy test.
@@ -1762,15 +1811,15 @@ class SegWitTest(BitcoinTestFramework):
         # Test 2: P2WSH
         # Try to spend the P2WSH output created in last test.
         # Send it to a P2SH(P2WSH) output, which we'll use in the next test.
-        p2sh_witness_hash = hash160(scriptWSH)
-        scriptP2SH = CScript([OP_HASH160, p2sh_witness_hash, OP_EQUAL])
-        scriptSig = CScript([scriptWSH])
+        p2sh_witness_hash = hash160(script_wsh)
+        script_p2sh = CScript([OP_HASH160, p2sh_witness_hash, OP_EQUAL])
+        script_sig = CScript([script_wsh])
 
         tx3 = CTransaction()
         tx3.vin.append(CTxIn(COutPoint(tx2.sha256, 0), b""))
-        tx3.vout.append(CTxOut(tx2.vout[0].nValue-1000, scriptP2SH))
+        tx3.vout.append(CTxOut(tx2.vout[0].nValue - 1000, script_p2sh))
         tx3.wit.vtxinwit.append(CTxInWitness())
-        sign_P2PK_witness_input(witness_program, tx3, 0, SIGHASH_ALL, tx2.vout[0].nValue, key)
+        sign_p2pk_witness_input(witness_program, tx3, 0, SIGHASH_ALL, tx2.vout[0].nValue, key)
 
         # Should fail policy test.
         test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx3, True, False, b'non-mandatory-script-verify-flag (Using non-compressed keys in segwit)')
@@ -1782,12 +1831,12 @@ class SegWitTest(BitcoinTestFramework):
         # Test 3: P2SH(P2WSH)
         # Try to spend the P2SH output created in the last test.
         # Send it to a P2PKH output, which we'll use in the next test.
-        scriptPubKey = GetP2PKHScript(pubkeyhash)
+        script_pubkey = get_p2pkh_script(pubkeyhash)
         tx4 = CTransaction()
-        tx4.vin.append(CTxIn(COutPoint(tx3.sha256, 0), scriptSig))
-        tx4.vout.append(CTxOut(tx3.vout[0].nValue-1000, scriptPubKey))
+        tx4.vin.append(CTxIn(COutPoint(tx3.sha256, 0), script_sig))
+        tx4.vout.append(CTxOut(tx3.vout[0].nValue - 1000, script_pubkey))
         tx4.wit.vtxinwit.append(CTxInWitness())
-        sign_P2PK_witness_input(witness_program, tx4, 0, SIGHASH_ALL, tx3.vout[0].nValue, key)
+        sign_p2pk_witness_input(witness_program, tx4, 0, SIGHASH_ALL, tx3.vout[0].nValue, key)
 
         # Should fail policy test.
         test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx4, True, False, b'non-mandatory-script-verify-flag (Using non-compressed keys in segwit)')
@@ -1799,9 +1848,9 @@ class SegWitTest(BitcoinTestFramework):
         # transactions.
         tx5 = CTransaction()
         tx5.vin.append(CTxIn(COutPoint(tx4.sha256, 0), b""))
-        tx5.vout.append(CTxOut(tx4.vout[0].nValue-1000, CScript([OP_TRUE])))
-        (sig_hash, err) = SignatureHash(scriptPubKey, tx5, 0, SIGHASH_ALL)
-        signature = key.sign(sig_hash) + b'\x01' # 0x1 is SIGHASH_ALL
+        tx5.vout.append(CTxOut(tx4.vout[0].nValue - 1000, CScript([OP_TRUE])))
+        (sig_hash, err) = SignatureHash(script_pubkey, tx5, 0, SIGHASH_ALL)
+        signature = key.sign(sig_hash) + b'\x01'  # 0x1 is SIGHASH_ALL
         tx5.vin[0].scriptSig = CScript([signature, pubkey])
         tx5.rehash()
         # Should pass policy and consensus.
@@ -1820,13 +1869,13 @@ class SegWitTest(BitcoinTestFramework):
         # in P2SH).
         p2sh_program = CScript([OP_TRUE])
         p2sh_pubkey = hash160(p2sh_program)
-        scriptPubKey = CScript([OP_HASH160, p2sh_pubkey, OP_EQUAL])
+        script_pubkey = CScript([OP_HASH160, p2sh_pubkey, OP_EQUAL])
 
         # Now check that unnecessary witnesses can't be used to blind a node
         # to a transaction, eg by violating standardness checks.
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, scriptPubKey))
+        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, script_pubkey))
         tx.rehash()
         test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx, False, True)
         self.nodes[0].generate(1)
@@ -1839,7 +1888,7 @@ class SegWitTest(BitcoinTestFramework):
         # to the rejection cache.
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), CScript([p2sh_program])))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, scriptPubKey))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, script_pubkey))
         tx2.wit.vtxinwit.append(CTxInWitness())
         tx2.wit.vtxinwit[0].scriptWitness.stack = [b'a' * 400]
         tx2.rehash()
@@ -1902,13 +1951,13 @@ class SegWitTest(BitcoinTestFramework):
         p2sh_txs = []
         for i in range(len(scripts)):
             p2wsh_tx = CTransaction()
-            p2wsh_tx.vin.append(CTxIn(COutPoint(txid,i*2)))
+            p2wsh_tx.vin.append(CTxIn(COutPoint(txid, i * 2)))
             p2wsh_tx.vout.append(CTxOut(outputvalue - 5000, CScript([OP_0, hash160(hex_str_to_bytes(""))])))
             p2wsh_tx.wit.vtxinwit.append(CTxInWitness())
             p2wsh_tx.rehash()
             p2wsh_txs.append(p2wsh_tx)
             p2sh_tx = CTransaction()
-            p2sh_tx.vin.append(CTxIn(COutPoint(txid,i*2+1), CScript([p2wsh_scripts[i]])))
+            p2sh_tx.vin.append(CTxIn(COutPoint(txid, i * 2 + 1), CScript([p2wsh_scripts[i]])))
             p2sh_tx.vout.append(CTxOut(outputvalue - 5000, CScript([OP_0, hash160(hex_str_to_bytes(""))])))
             p2sh_tx.wit.vtxinwit.append(CTxInWitness())
             p2sh_tx.rehash()
@@ -1968,11 +2017,11 @@ class SegWitTest(BitcoinTestFramework):
     def run_test(self):
         # Setup the p2p connections
         # self.test_node sets NODE_WITNESS|NODE_NETWORK
-        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK|NODE_WITNESS)
+        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK | NODE_WITNESS)
         # self.old_node sets only NODE_NETWORK
         self.old_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
         # self.std_node is for testing node1 (fRequireStandard=true)
-        self.std_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK|NODE_WITNESS)
+        self.std_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK | NODE_WITNESS)
 
         # Keep a place to store utxo's that can be used in later tests
         self.utxo = []
@@ -1982,8 +2031,8 @@ class SegWitTest(BitcoinTestFramework):
 
         self.log.info("Starting tests before segwit lock in:")
 
-        self.test_witness_services() # Verifies NODE_WITNESS
-        self.test_non_witness_transaction() # non-witness tx's are accepted
+        self.test_witness_services()  # Verifies NODE_WITNESS
+        self.test_non_witness_transaction()  # non-witness tx's are accepted
         self.test_unnecessary_witness_before_segwit_activation()
         self.test_v0_outputs_arent_spendable()
         self.test_block_relay(segwit_activated=False)
@@ -2035,7 +2084,6 @@ class SegWitTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
         self.test_upgrade_after_activation(node_id=2)
         self.test_witness_sigops()
-
 
 if __name__ == '__main__':
     SegWitTest().main()

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -91,9 +91,10 @@ VB_TOP_BITS = 0x20000000
 MAX_SIGOP_COST = 80000
 
 
-# Calculate the virtual size of a witness block:
-# (base + witness/4)
 def get_virtual_size(witness_block):
+    """Calculate the virtual size of a witness block.
+
+    Virtual size is base + witness/4."""
     base_size = len(witness_block.serialize(with_witness=False))
     total_size = len(witness_block.serialize(with_witness=True))
     # the "+3" is so we round up
@@ -172,24 +173,23 @@ class TestP2PConn(P2PInterface):
         self.wait_for_block(blockhash, timeout)
         return self.last_message["block"].block
 
-# Used to keep track of anyone-can-spend outputs that we can use in the tests
 class UTXO():
+    """Used to keep track of anyone-can-spend outputs that we can use in the tests."""
     def __init__(self, sha256, n, value):
         self.sha256 = sha256
         self.n = n
         self.nValue = value
 
-# Helper for getting the script associated with a P2PKH
 def get_p2pkh_script(pubkeyhash):
+    """Get the script associated with a P2PKH."""
     return CScript([CScriptOp(OP_DUP), CScriptOp(OP_HASH160), pubkeyhash, CScriptOp(OP_EQUALVERIFY), CScriptOp(OP_CHECKSIG)])
 
-# Add signature for a P2PK witness program.
 def sign_p2pk_witness_input(script, tx_to, in_idx, hashtype, value, key):
+    """Add signature for a P2PK witness program."""
     tx_hash = SegwitVersion1SignatureHash(script, tx_to, in_idx, hashtype, value)
     signature = key.sign(tx_hash) + chr(hashtype).encode('latin-1')
     tx_to.wit.vtxinwit[in_idx].scriptWitness.stack = [signature, script]
     tx_to.rehash()
-
 
 class SegWitTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -204,9 +204,10 @@ class SegWitTest(BitcoinTestFramework):
         connect_nodes(self.nodes[0], 2)
         self.sync_all()
 
-    ''' Helpers '''
-    # Build a block on top of node0's tip.
+    # Helper functions
+
     def build_next_block(self, version=4):
+        """Build a block on top of node0's tip."""
         tip = self.nodes[0].getbestblockhash()
         height = self.nodes[0].getblockcount() + 1
         block_time = self.nodes[0].getblockheader(tip)["mediantime"] + 1
@@ -215,21 +216,21 @@ class SegWitTest(BitcoinTestFramework):
         block.rehash()
         return block
 
-    # Adds list of transactions to block, adds witness commitment, then solves.
     def update_witness_block_with_transactions(self, block, tx_list, nonce=0):
+        """Add list of transactions to block, adds witness commitment, then solves."""
         block.vtx.extend(tx_list)
         add_witness_commitment(block, nonce)
         block.solve()
         return
 
-    ''' Individual tests '''
+    # Individual tests
+
     def test_witness_services(self):
         self.log.info("Verifying NODE_WITNESS service bit")
         assert((self.test_node.nServices & NODE_WITNESS) != 0)
 
-    # See if sending a regular transaction works, and create a utxo
-    # to use in later tests.
     def test_non_witness_transaction(self):
+        """See if sending a regular transaction works, and create a utxo to use in later tests."""
         # Mine a block with an anyone-can-spend coinbase,
         # let it mature, then try to spend it.
         self.log.info("Testing non-witness transaction")
@@ -258,8 +259,8 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.append(UTXO(tx.sha256, 0, 49 * 100000000))
         self.nodes[0].generate(1)
 
-    # Verify that blocks with witnesses are rejected before activation.
     def test_unnecessary_witness_before_segwit_activation(self):
+        """Verify that blocks with witnesses are rejected before activation."""
         self.log.info("Testing behavior of unnecessary witnesses")
         # For now, rely on earlier tests to have created at least one utxo for
         # us to use
@@ -300,14 +301,17 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx.sha256, 0, tx.vout[0].nValue))
 
-    # ~6 months after segwit activation, the SCRIPT_VERIFY_WITNESS flag was
-    # backdated so that it applies to all blocks, going back to the genesis
-    # block.
-    #
-    # Consequently, version 0 witness outputs are never spendable without
-    # witness, and so can't be spent before segwit activation (the point at which
-    # blocks are permitted to contain witnesses).
     def test_v0_outputs_arent_spendable(self):
+        """Test that v0 outputs aren't spendable before segwit activation.
+
+        ~6 months after segwit activation, the SCRIPT_VERIFY_WITNESS flag was
+        backdated so that it applies to all blocks, going back to the genesis
+        block.
+
+        Consequently, version 0 witness outputs are never spendable without
+        witness, and so can't be spent before segwit activation (the point at which
+        blocks are permitted to contain witnesses)."""
+
         self.log.info("Testing that v0 witness program outputs aren't spendable before activation")
 
         assert len(self.utxo), "self.utxo is empty"
@@ -375,8 +379,8 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(txid, 2, value))
 
-    # Mine enough blocks for segwit's vb state to be 'started'.
     def advance_to_segwit_started(self):
+        """Mine enough blocks for segwit's vb state to be 'started'."""
         height = self.nodes[0].getblockcount()
         # Will need to rewrite the tests here if we are past the first period
         assert(height < VB_PERIOD - 1)
@@ -386,10 +390,11 @@ class SegWitTest(BitcoinTestFramework):
         self.nodes[0].generate(VB_PERIOD - height - 1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'started')
 
-    # Mine enough blocks to lock in segwit, but don't activate.
-    # TODO: we could verify that lockin only happens at the right threshold of
-    # signalling blocks, rather than just at the right period boundary.
     def advance_to_segwit_lockin(self):
+        """Mine enough blocks to lock in segwit, but don't activate."""
+        # TODO: we could verify that lockin only happens at the right threshold of
+        # signalling blocks, rather than just at the right period boundary.
+
         height = self.nodes[0].getblockcount()
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'started')
         # Advance to end of period, and verify lock-in happens at the end
@@ -400,10 +405,11 @@ class SegWitTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
 
-    # Mine enough blocks to activate segwit.
-    # TODO: we could verify that activation only happens at the right threshold
-    # of signalling blocks, rather than just at the right period boundary.
     def advance_to_segwit_active(self):
+        """Mine enough blocks to activate segwit."""
+        # TODO: we could verify that activation only happens at the right threshold
+        # of signalling blocks, rather than just at the right period boundary.
+
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
         height = self.nodes[0].getblockcount()
         self.nodes[0].generate(VB_PERIOD - (height % VB_PERIOD) - 2)
@@ -411,8 +417,11 @@ class SegWitTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'active')
 
-    # This test can only be run after segwit has activated
     def test_witness_commitments(self):
+        """Test witness commitments.
+
+        This test can only be run after segwit has activated."""
+
         self.log.info("Testing witness commitments")
 
         # First try a correct witness commitment.
@@ -618,9 +627,8 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue))
 
-    # submitblock will try to add the nonce automatically, so that mining
-    # software doesn't need to worry about doing so itself.
     def test_submit_block(self):
+        """Test that submitblock adds the nonce automatically when possible."""
         block = self.build_next_block()
 
         # Try using a custom nonce and then don't supply it.
@@ -654,8 +662,8 @@ class SegWitTest(BitcoinTestFramework):
         # Tip should not advance!
         assert(self.nodes[0].getbestblockhash() != block_2.hash)
 
-    # Consensus tests of extra witness data in a transaction.
     def test_extra_witness_data(self):
+        """Test extra witness data in a transaction."""
         self.log.info("Testing extra witness data in tx")
 
         assert(len(self.utxo) > 0)
@@ -730,7 +738,7 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.append(UTXO(tx2.sha256, 0, tx2.vout[0].nValue))
 
     def test_max_witness_push_length(self):
-        ''' Should only allow up to 520 byte pushes in witness stack '''
+        """Test that witness stack can only allow up to 520 byte pushes."""
         self.log.info("Testing maximum witness push size")
         MAX_SCRIPT_ELEMENT_SIZE = 520
         assert(len(self.utxo))
@@ -769,8 +777,7 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.append(UTXO(tx2.sha256, 0, tx2.vout[0].nValue))
 
     def test_max_witness_program_length(self):
-        # Can create witness outputs that are long, but can't be greater than
-        # 10k bytes to successfully spend
+        """Test that witness outputs greater than 10kB can't be spent."""
         self.log.info("Testing maximum witness program length")
         assert(len(self.utxo))
         MAX_PROGRAM_LENGTH = 10000
@@ -818,7 +825,7 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.append(UTXO(tx2.sha256, 0, tx2.vout[0].nValue))
 
     def test_witness_input_length(self):
-        ''' Ensure that vin length must match vtxinwit length '''
+        """Test that vin length must match vtxinwit length."""
         self.log.info("Testing witness input length")
         assert(len(self.utxo))
 
@@ -942,11 +949,14 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx_hash, 0, tx_value))
 
-    # After segwit activates, verify that mempool:
-    # - rejects transactions with unnecessary/extra witnesses
-    # - accepts transactions with valid witnesses
-    # and that witness transactions are relayed to non-upgraded peers.
     def test_tx_relay_after_segwit_activation(self):
+        """Test transaction relay after segwit activation.
+
+        After segwit activates, verify that mempool:
+        - rejects transactions with unnecessary/extra witnesses
+        - accepts transactions with valid witnesses
+        and that witness transactions are relayed to non-upgraded peers."""
+
         self.log.info("Testing relay of witness transactions")
         # Generate a transaction that doesn't require a witness, but send it
         # with a witness.  Should be rejected because we can't use a witness
@@ -1033,10 +1043,11 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
 
-    # Test that block requests to NODE_WITNESS peer are with MSG_WITNESS_FLAG
-    # This is true regardless of segwit activation.
-    # Also test that we don't ask for blocks from unupgraded peers
     def test_block_relay(self, segwit_activated):
+        """Test that block requests to NODE_WITNESS peer are with MSG_WITNESS_FLAG.
+
+        This is true regardless of segwit activation.
+        Also test that we don't ask for blocks from unupgraded peers."""
         self.log.info("Testing block relay")
 
         blocktype = 2 | MSG_WITNESS_FLAG
@@ -1128,8 +1139,12 @@ class SegWitTest(BitcoinTestFramework):
             self.old_node.announce_tx_and_wait_for_getdata(block4.vtx[0])
             assert(block4.sha256 not in self.old_node.getdataset)
 
-    # V0 segwit outputs and inputs are always standard. V0 segwit inputs may only be mined after activation, but not before.
     def test_standardness_v0(self, segwit_activated):
+        """Test V0 txout standardness.
+        
+        V0 segwit outputs and inputs are always standard.
+        V0 segwit inputs may only be mined after activation, but not before."""
+
         self.log.info("Testing standardness of v0 outputs (%s activation)" % ("after" if segwit_activated else "before"))
         assert(len(self.utxo))
 
@@ -1204,9 +1219,12 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
         assert_equal(len(self.nodes[1].getrawmempool()), 0)
 
-    # Verify that future segwit upgraded transactions are non-standard,
-    # but valid in blocks. Can run this before and after segwit activation.
     def test_segwit_versions(self):
+        """Test validity of future segwit version transactions.
+        
+        Future segwit version transactions are non-standard, but valid in blocks.
+        Can run this before and after segwit activation."""
+
         self.log.info("Testing standardness/consensus for segwit versions (0-16)")
         assert(len(self.utxo))
         num_tests = 17  # will test OP_0, OP1, ..., OP_16
@@ -1505,8 +1523,8 @@ class SegWitTest(BitcoinTestFramework):
         for i in range(len(tx.vout)):
             self.utxo.append(UTXO(tx.sha256, i, tx.vout[i].nValue))
 
-    # Test P2SH wrapped witness programs.
     def test_p2sh_witness(self, segwit_activated):
+        """Test P2SH wrapped witness programs."""
         self.log.info("Testing P2SH witness transactions")
 
         assert(len(self.utxo))
@@ -1575,12 +1593,8 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(spend_tx.sha256, 0, spend_tx.vout[0].nValue))
 
-    # Test the behavior of starting up a segwit-aware node after the softfork
-    # has activated.  As segwit requires different block data than pre-segwit
-    # nodes would have stored, this requires special handling.
-    # To enable this test, pass --oldbinary=<path-to-pre-segwit-bitcoind> to
-    # the test.
     def test_upgrade_after_activation(self, node_id):
+        """Test the behavior of starting up a segwit-aware node after the softfork has activated."""
         self.log.info("Testing software upgrade after softfork activation")
 
         assert(node_id != 0)  # node0 is assumed to be a segwit-active bitcoind
@@ -1607,7 +1621,7 @@ class SegWitTest(BitcoinTestFramework):
             height -= 1
 
     def test_witness_sigops(self):
-        '''Ensure sigop counting is correct inside witnesses.'''
+        """Test sigop counting is correct inside witnesses."""
         self.log.info("Testing sigops limit")
 
         assert(len(self.utxo))
@@ -1756,9 +1770,12 @@ class SegWitTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(0)
         self.nodes[2].setmocktime(0)
 
-    # Uncompressed pubkeys are no longer supported in default relay policy,
-    # but (for now) are still valid in blocks.
     def test_uncompressed_pubkey(self):
+        """Test uncompressed pubkey validity in segwit transactions.
+
+        Uncompressed pubkeys are no longer supported in default relay policy,
+        but (for now) are still valid in blocks."""
+
         self.log.info("Testing uncompressed pubkeys")
         # Segwit transactions using uncompressed pubkeys are not accepted
         # under default policy, but should still pass consensus.

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -41,7 +41,6 @@ from test_framework.messages import (
 from test_framework.mininode import (
     P2PInterface,
     mininode_lock,
-    network_thread_start,
 )
 from test_framework.script import (
     CScript,
@@ -90,6 +89,23 @@ VB_TOP_BITS = 0x20000000
 
 MAX_SIGOP_COST = 80000
 
+class UTXO():
+    """Used to keep track of anyone-can-spend outputs that we can use in the tests."""
+    def __init__(self, sha256, n, value):
+        self.sha256 = sha256
+        self.n = n
+        self.nValue = value
+
+def get_p2pkh_script(pubkeyhash):
+    """Get the script associated with a P2PKH."""
+    return CScript([CScriptOp(OP_DUP), CScriptOp(OP_HASH160), pubkeyhash, CScriptOp(OP_EQUALVERIFY), CScriptOp(OP_CHECKSIG)])
+
+def sign_p2pk_witness_input(script, tx_to, in_idx, hashtype, value, key):
+    """Add signature for a P2PK witness program."""
+    tx_hash = SegwitVersion1SignatureHash(script, tx_to, in_idx, hashtype, value)
+    signature = key.sign(tx_hash) + chr(hashtype).encode('latin-1')
+    tx_to.wit.vtxinwit[in_idx].scriptWitness.stack = [signature, script]
+    tx_to.rehash()
 
 def get_virtual_size(witness_block):
     """Calculate the virtual size of a witness block.
@@ -173,24 +189,6 @@ class TestP2PConn(P2PInterface):
         self.wait_for_block(blockhash, timeout)
         return self.last_message["block"].block
 
-class UTXO():
-    """Used to keep track of anyone-can-spend outputs that we can use in the tests."""
-    def __init__(self, sha256, n, value):
-        self.sha256 = sha256
-        self.n = n
-        self.nValue = value
-
-def get_p2pkh_script(pubkeyhash):
-    """Get the script associated with a P2PKH."""
-    return CScript([CScriptOp(OP_DUP), CScriptOp(OP_HASH160), pubkeyhash, CScriptOp(OP_EQUALVERIFY), CScriptOp(OP_CHECKSIG)])
-
-def sign_p2pk_witness_input(script, tx_to, in_idx, hashtype, value, key):
-    """Add signature for a P2PK witness program."""
-    tx_hash = SegwitVersion1SignatureHash(script, tx_to, in_idx, hashtype, value)
-    signature = key.sign(tx_hash) + chr(hashtype).encode('latin-1')
-    tx_to.wit.vtxinwit[in_idx].scriptWitness.stack = [signature, script]
-    tx_to.rehash()
-
 class SegWitTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
@@ -221,7 +219,77 @@ class SegWitTest(BitcoinTestFramework):
         block.vtx.extend(tx_list)
         add_witness_commitment(block, nonce)
         block.solve()
-        return
+
+    def run_test(self):
+        # Setup the p2p connections and start up the network thread.
+        # self.test_node sets NODE_WITNESS|NODE_NETWORK
+        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK | NODE_WITNESS)
+        # self.old_node sets only NODE_NETWORK
+        self.old_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
+        # self.std_node is for testing node1 (fRequireStandard=true)
+        self.std_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK | NODE_WITNESS)
+
+        # Keep a place to store utxo's that can be used in later tests
+        self.utxo = []
+
+        # Test logic begins here
+        self.test_node.wait_for_verack()
+
+        self.log.info("Starting tests before segwit lock in:")
+
+        self.test_witness_services()  # Verifies NODE_WITNESS
+        self.test_non_witness_transaction()  # non-witness tx's are accepted
+        self.test_unnecessary_witness_before_segwit_activation()
+        self.test_v0_outputs_arent_spendable()
+        self.test_block_relay(segwit_activated=False)
+
+        # Advance to segwit being 'started'
+        self.advance_to_segwit_started()
+        sync_blocks(self.nodes)
+        self.test_getblocktemplate_before_lockin()
+
+        sync_blocks(self.nodes)
+
+        # At lockin, nothing should change.
+        self.log.info("Testing behavior post lockin, pre-activation")
+        self.advance_to_segwit_lockin()
+
+        # Retest unnecessary witnesses
+        self.test_unnecessary_witness_before_segwit_activation()
+        self.test_witness_tx_relay_before_segwit_activation()
+        self.test_block_relay(segwit_activated=False)
+        self.test_standardness_v0(segwit_activated=False)
+
+        sync_blocks(self.nodes)
+
+        # Now activate segwit
+        self.log.info("Testing behavior after segwit activation")
+        self.advance_to_segwit_active()
+
+        sync_blocks(self.nodes)
+
+        # Test P2SH witness handling again
+        self.test_p2sh_witness(segwit_activated=True)
+        self.test_witness_commitments()
+        self.test_block_malleability()
+        self.test_witness_block_size()
+        self.test_submit_block()
+        self.test_extra_witness_data()
+        self.test_max_witness_push_length()
+        self.test_max_witness_program_length()
+        self.test_witness_input_length()
+        self.test_block_relay(segwit_activated=True)
+        self.test_tx_relay_after_segwit_activation()
+        self.test_standardness_v0(segwit_activated=True)
+        self.test_segwit_versions()
+        self.test_premature_coinbase_witness_spend()
+        self.test_uncompressed_pubkey()
+        self.test_signature_version_1()
+        self.test_non_standard_witness_blinding()
+        self.test_non_standard_witness()
+        sync_blocks(self.nodes)
+        self.test_upgrade_after_activation(node_id=2)
+        self.test_witness_sigops()
 
     # Individual tests
 
@@ -300,6 +368,102 @@ class SegWitTest(BitcoinTestFramework):
         # Update our utxo list; we spent the first entry.
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx.sha256, 0, tx.vout[0].nValue))
+
+    def test_block_relay(self, segwit_activated):
+        """Test that block requests to NODE_WITNESS peer are with MSG_WITNESS_FLAG.
+
+        This is true regardless of segwit activation.
+        Also test that we don't ask for blocks from unupgraded peers."""
+        self.log.info("Testing block relay")
+
+        blocktype = 2 | MSG_WITNESS_FLAG
+
+        # test_node has set NODE_WITNESS, so all getdata requests should be for
+        # witness blocks.
+        # Test announcing a block via inv results in a getdata, and that
+        # announcing a version 4 or random VB block with a header results in a getdata
+        block1 = self.build_next_block()
+        block1.solve()
+
+        self.test_node.announce_block_and_wait_for_getdata(block1, use_header=False)
+        assert(self.test_node.last_message["getdata"].inv[0].type == blocktype)
+        test_witness_block(self.nodes[0].rpc, self.test_node, block1, True)
+
+        block2 = self.build_next_block(version=4)
+        block2.solve()
+
+        self.test_node.announce_block_and_wait_for_getdata(block2, use_header=True)
+        assert(self.test_node.last_message["getdata"].inv[0].type == blocktype)
+        test_witness_block(self.nodes[0].rpc, self.test_node, block2, True)
+
+        block3 = self.build_next_block(version=(VB_TOP_BITS | (1 << 15)))
+        block3.solve()
+        self.test_node.announce_block_and_wait_for_getdata(block3, use_header=True)
+        assert(self.test_node.last_message["getdata"].inv[0].type == blocktype)
+        test_witness_block(self.nodes[0].rpc, self.test_node, block3, True)
+
+        # Check that we can getdata for witness blocks or regular blocks,
+        # and the right thing happens.
+        if not segwit_activated:
+            # Before activation, we should be able to request old blocks with
+            # or without witness, and they should be the same.
+            chain_height = self.nodes[0].getblockcount()
+            # Pick 10 random blocks on main chain, and verify that getdata's
+            # for MSG_BLOCK, MSG_WITNESS_BLOCK, and rpc getblock() are equal.
+            all_heights = list(range(chain_height + 1))
+            random.shuffle(all_heights)
+            all_heights = all_heights[0:10]
+            for height in all_heights:
+                block_hash = self.nodes[0].getblockhash(height)
+                rpc_block = self.nodes[0].getblock(block_hash, False)
+                block_hash = int(block_hash, 16)
+                block = self.test_node.request_block(block_hash, 2)
+                wit_block = self.test_node.request_block(block_hash, 2 | MSG_WITNESS_FLAG)
+                assert_equal(block.serialize(True), wit_block.serialize(True))
+                assert_equal(block.serialize(), hex_str_to_bytes(rpc_block))
+        else:
+            # After activation, witness blocks and non-witness blocks should
+            # be different.  Verify rpc getblock() returns witness blocks, while
+            # getdata respects the requested type.
+            block = self.build_next_block()
+            self.update_witness_block_with_transactions(block, [])
+            # This gives us a witness commitment.
+            assert(len(block.vtx[0].wit.vtxinwit) == 1)
+            assert(len(block.vtx[0].wit.vtxinwit[0].scriptWitness.stack) == 1)
+            test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
+            # Now try to retrieve it...
+            rpc_block = self.nodes[0].getblock(block.hash, False)
+            non_wit_block = self.test_node.request_block(block.sha256, 2)
+            wit_block = self.test_node.request_block(block.sha256, 2 | MSG_WITNESS_FLAG)
+            assert_equal(wit_block.serialize(True), hex_str_to_bytes(rpc_block))
+            assert_equal(wit_block.serialize(False), non_wit_block.serialize())
+            assert_equal(wit_block.serialize(True), block.serialize(True))
+
+            # Test size, vsize, weight
+            rpc_details = self.nodes[0].getblock(block.hash, True)
+            assert_equal(rpc_details["size"], len(block.serialize(True)))
+            assert_equal(rpc_details["strippedsize"], len(block.serialize(False)))
+            weight = 3 * len(block.serialize(False)) + len(block.serialize(True))
+            assert_equal(rpc_details["weight"], weight)
+
+            # Upgraded node should not ask for blocks from unupgraded
+            block4 = self.build_next_block(version=4)
+            block4.solve()
+            self.old_node.getdataset = set()
+
+            # Blocks can be requested via direct-fetch (immediately upon processing the announcement)
+            # or via parallel download (with an indeterminate delay from processing the announcement)
+            # so to test that a block is NOT requested, we could guess a time period to sleep for,
+            # and then check. We can avoid the sleep() by taking advantage of transaction getdata's
+            # being processed after block getdata's, and announce a transaction as well,
+            # and then check to see if that particular getdata has been received.
+            # Since 0.14, inv's will only be responded to with a getheaders, so send a header
+            # to announce this block.
+            msg = msg_headers()
+            msg.headers = [CBlockHeader(block4)]
+            self.old_node.send_message(msg)
+            self.old_node.announce_tx_and_wait_for_getdata(block4.vtx[0])
+            assert(block4.sha256 not in self.old_node.getdataset)
 
     def test_v0_outputs_arent_spendable(self):
         """Test that v0 outputs aren't spendable before segwit activation.
@@ -390,6 +554,53 @@ class SegWitTest(BitcoinTestFramework):
         self.nodes[0].generate(VB_PERIOD - height - 1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'started')
 
+    def test_getblocktemplate_before_lockin(self):
+        self.log.info("Testing getblocktemplate setting of segwit versionbit (before lockin)")
+        # Node0 is segwit aware, node2 is not.
+        for node in [self.nodes[0], self.nodes[2]]:
+            gbt_results = node.getblocktemplate()
+            block_version = gbt_results['version']
+            # If we're not indicating segwit support, we will still be
+            # signalling for segwit activation.
+            assert_equal((block_version & (1 << VB_WITNESS_BIT) != 0), node == self.nodes[0])
+            # If we don't specify the segwit rule, then we won't get a default
+            # commitment.
+            assert('default_witness_commitment' not in gbt_results)
+
+        # Workaround:
+        # Can either change the tip, or change the mempool and wait 5 seconds
+        # to trigger a recomputation of getblocktemplate.
+        txid = int(self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1), 16)
+        # Using mocktime lets us avoid sleep()
+        sync_mempools(self.nodes)
+        self.nodes[0].setmocktime(int(time.time()) + 10)
+        self.nodes[2].setmocktime(int(time.time()) + 10)
+
+        for node in [self.nodes[0], self.nodes[2]]:
+            gbt_results = node.getblocktemplate({"rules": ["segwit"]})
+            block_version = gbt_results['version']
+            if node == self.nodes[2]:
+                # If this is a non-segwit node, we should still not get a witness
+                # commitment, nor a version bit signalling segwit.
+                assert_equal(block_version & (1 << VB_WITNESS_BIT), 0)
+                assert('default_witness_commitment' not in gbt_results)
+            else:
+                # For segwit-aware nodes, check the version bit and the witness
+                # commitment are correct.
+                assert(block_version & (1 << VB_WITNESS_BIT) != 0)
+                assert('default_witness_commitment' in gbt_results)
+                witness_commitment = gbt_results['default_witness_commitment']
+
+                # Check that default_witness_commitment is present.
+                witness_root = CBlock.get_merkle_root([ser_uint256(0),
+                                                       ser_uint256(txid)])
+                script = get_witness_script(witness_root, 0)
+                assert_equal(witness_commitment, bytes_to_hex_str(script))
+
+        # undo mocktime
+        self.nodes[0].setmocktime(0)
+        self.nodes[2].setmocktime(0)
+
     def advance_to_segwit_lockin(self):
         """Mine enough blocks to lock in segwit, but don't activate."""
         # TODO: we could verify that lockin only happens at the right threshold of
@@ -405,6 +616,128 @@ class SegWitTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
 
+    def test_witness_tx_relay_before_segwit_activation(self):
+        self.log.info("Testing relay of witness transactions")
+        # Generate a transaction that doesn't require a witness, but send it
+        # with a witness.  Should be rejected for premature-witness, but should
+        # not be added to recently rejected list.
+        assert(len(self.utxo))
+        tx = CTransaction()
+        tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
+        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))
+        tx.wit.vtxinwit.append(CTxInWitness())
+        tx.wit.vtxinwit[0].scriptWitness.stack = [b'a']
+        tx.rehash()
+
+        tx_hash = tx.sha256
+        tx_value = tx.vout[0].nValue
+
+        # Verify that if a peer doesn't set nServices to include NODE_WITNESS,
+        # the getdata is just for the non-witness portion.
+        self.old_node.announce_tx_and_wait_for_getdata(tx)
+        assert(self.old_node.last_message["getdata"].inv[0].type == 1)
+
+        # Since we haven't delivered the tx yet, inv'ing the same tx from
+        # a witness transaction ought not result in a getdata.
+        self.test_node.announce_tx_and_wait_for_getdata(tx, timeout=2, success=False)
+
+        # Delivering this transaction with witness should fail (no matter who
+        # its from)
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
+        assert_equal(len(self.nodes[1].getrawmempool()), 0)
+        test_transaction_acceptance(self.nodes[0].rpc, self.old_node, tx, with_witness=True, accepted=False)
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx, with_witness=True, accepted=False)
+
+        # But eliminating the witness should fix it
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx, with_witness=False, accepted=True)
+
+        # Cleanup: mine the first transaction and update utxo
+        self.nodes[0].generate(1)
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
+
+        self.utxo.pop(0)
+        self.utxo.append(UTXO(tx_hash, 0, tx_value))
+
+    def test_standardness_v0(self, segwit_activated):
+        """Test V0 txout standardness.
+
+        V0 segwit outputs and inputs are always standard.
+        V0 segwit inputs may only be mined after activation, but not before."""
+
+        self.log.info("Testing standardness of v0 outputs (%s activation)" % ("after" if segwit_activated else "before"))
+        assert(len(self.utxo))
+
+        witness_program = CScript([OP_TRUE])
+        witness_hash = sha256(witness_program)
+        script_pubkey = CScript([OP_0, witness_hash])
+
+        p2sh_pubkey = hash160(witness_program)
+        p2sh_script_pubkey = CScript([OP_HASH160, p2sh_pubkey, OP_EQUAL])
+
+        # First prepare a p2sh output (so that spending it will pass standardness)
+        p2sh_tx = CTransaction()
+        p2sh_tx.vin = [CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b"")]
+        p2sh_tx.vout = [CTxOut(self.utxo[0].nValue - 1000, p2sh_script_pubkey)]
+        p2sh_tx.rehash()
+
+        # Mine it on test_node to create the confirmed output.
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, p2sh_tx, with_witness=True, accepted=True)
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # Now test standardness of v0 P2WSH outputs.
+        # Start by creating a transaction with two outputs.
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(p2sh_tx.sha256, 0), CScript([witness_program]))]
+        tx.vout = [CTxOut(p2sh_tx.vout[0].nValue - 10000, script_pubkey)]
+        tx.vout.append(CTxOut(8000, script_pubkey))  # Might burn this later
+        tx.vin[0].nSequence = BIP125_SEQUENCE_NUMBER  # Just to have the option to bump this tx from the mempool
+        tx.rehash()
+
+        # This is always accepted, since the mempool policy is to consider segwit as always active
+        # and thus allow segwit outputs
+        test_transaction_acceptance(self.nodes[1].rpc, self.std_node, tx, with_witness=True, accepted=True)
+
+        # Now create something that looks like a P2PKH output. This won't be spendable.
+        script_pubkey = CScript([OP_0, hash160(witness_hash)])
+        tx2 = CTransaction()
+        # tx was accepted, so we spend the second output.
+        tx2.vin = [CTxIn(COutPoint(tx.sha256, 1), b"")]
+        tx2.vout = [CTxOut(7000, script_pubkey)]
+        tx2.wit.vtxinwit.append(CTxInWitness())
+        tx2.wit.vtxinwit[0].scriptWitness.stack = [witness_program]
+        tx2.rehash()
+
+        test_transaction_acceptance(self.nodes[1].rpc, self.std_node, tx2, with_witness=True, accepted=True)
+
+        # Now update self.utxo for later tests.
+        tx3 = CTransaction()
+        # tx and tx2 were both accepted.  Don't bother trying to reclaim the
+        # P2PKH output; just send tx's first output back to an anyone-can-spend.
+        sync_mempools([self.nodes[0], self.nodes[1]])
+        tx3.vin = [CTxIn(COutPoint(tx.sha256, 0), b"")]
+        tx3.vout = [CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE]))]
+        tx3.wit.vtxinwit.append(CTxInWitness())
+        tx3.wit.vtxinwit[0].scriptWitness.stack = [witness_program]
+        tx3.rehash()
+        if not segwit_activated:
+            # Just check mempool acceptance, but don't add the transaction to the mempool, since witness is disallowed
+            # in blocks and the tx is impossible to mine right now.
+            assert_equal(self.nodes[0].testmempoolaccept([bytes_to_hex_str(tx3.serialize_with_witness())]), [{'txid': tx3.hash, 'allowed': True}])
+            # Create the same output as tx3, but by replacing tx
+            tx3_out = tx3.vout[0]
+            tx3 = tx
+            tx3.vout = [tx3_out]
+            tx3.rehash()
+            assert_equal(self.nodes[0].testmempoolaccept([bytes_to_hex_str(tx3.serialize_with_witness())]), [{'txid': tx3.hash, 'allowed': True}])
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx3, with_witness=True, accepted=True)
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+        self.utxo.pop(0)
+        self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
+        assert_equal(len(self.nodes[1].getrawmempool()), 0)
+
     def advance_to_segwit_active(self):
         """Mine enough blocks to activate segwit."""
         # TODO: we could verify that activation only happens at the right threshold
@@ -416,6 +749,76 @@ class SegWitTest(BitcoinTestFramework):
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
         self.nodes[0].generate(1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'active')
+
+    def test_p2sh_witness(self, segwit_activated):
+        """Test P2SH wrapped witness programs."""
+        self.log.info("Testing P2SH witness transactions")
+
+        assert(len(self.utxo))
+
+        # Prepare the p2sh-wrapped witness output
+        witness_program = CScript([OP_DROP, OP_TRUE])
+        witness_hash = sha256(witness_program)
+        p2wsh_pubkey = CScript([OP_0, witness_hash])
+        p2sh_witness_hash = hash160(p2wsh_pubkey)
+        script_pubkey = CScript([OP_HASH160, p2sh_witness_hash, OP_EQUAL])
+        script_sig = CScript([p2wsh_pubkey])  # a push of the redeem script
+
+        # Fund the P2SH output
+        tx = CTransaction()
+        tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
+        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, script_pubkey))
+        tx.rehash()
+
+        # Verify mempool acceptance and block validity
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx, with_witness=False, accepted=True)
+        block = self.build_next_block()
+        self.update_witness_block_with_transactions(block, [tx])
+        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True, with_witness=segwit_activated)
+        sync_blocks(self.nodes)
+
+        # Now test attempts to spend the output.
+        spend_tx = CTransaction()
+        spend_tx.vin.append(CTxIn(COutPoint(tx.sha256, 0), script_sig))
+        spend_tx.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE])))
+        spend_tx.rehash()
+
+        # This transaction should not be accepted into the mempool pre- or
+        # post-segwit.  Mempool acceptance will use SCRIPT_VERIFY_WITNESS which
+        # will require a witness to spend a witness program regardless of
+        # segwit activation.  Note that older bitcoind's that are not
+        # segwit-aware would also reject this for failing CLEANSTACK.
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, spend_tx, with_witness=False, accepted=False)
+
+        # Try to put the witness script in the script_sig, should also fail.
+        spend_tx.vin[0].script_sig = CScript([p2wsh_pubkey, b'a'])
+        spend_tx.rehash()
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, spend_tx, with_witness=False, accepted=False)
+
+        # Now put the witness script in the witness, should succeed after
+        # segwit activates.
+        spend_tx.vin[0].scriptSig = script_sig
+        spend_tx.rehash()
+        spend_tx.wit.vtxinwit.append(CTxInWitness())
+        spend_tx.wit.vtxinwit[0].scriptWitness.stack = [b'a', witness_program]
+
+        # Verify mempool acceptance
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, spend_tx, with_witness=True, accepted=segwit_activated)
+        block = self.build_next_block()
+        self.update_witness_block_with_transactions(block, [spend_tx])
+
+        # If we're after activation, then sending this with witnesses should be valid.
+        # This no longer works before activation, because SCRIPT_VERIFY_WITNESS
+        # is always set.
+        # TODO: rewrite this test to make clear that it only works after activation.
+        if segwit_activated:
+            test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
+        else:
+            test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True, with_witness=False)
+
+        # Update self.utxo
+        self.utxo.pop(0)
+        self.utxo.append(UTXO(spend_tx.sha256, 0, spend_tx.vout[0].nValue))
 
     def test_witness_commitments(self):
         """Test witness commitments.
@@ -907,48 +1310,6 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop()
         self.utxo.append(UTXO(tx2.sha256, 0, tx2.vout[0].nValue))
 
-    def test_witness_tx_relay_before_segwit_activation(self):
-        self.log.info("Testing relay of witness transactions")
-        # Generate a transaction that doesn't require a witness, but send it
-        # with a witness.  Should be rejected for premature-witness, but should
-        # not be added to recently rejected list.
-        assert(len(self.utxo))
-        tx = CTransaction()
-        tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))
-        tx.wit.vtxinwit.append(CTxInWitness())
-        tx.wit.vtxinwit[0].scriptWitness.stack = [b'a']
-        tx.rehash()
-
-        tx_hash = tx.sha256
-        tx_value = tx.vout[0].nValue
-
-        # Verify that if a peer doesn't set nServices to include NODE_WITNESS,
-        # the getdata is just for the non-witness portion.
-        self.old_node.announce_tx_and_wait_for_getdata(tx)
-        assert(self.old_node.last_message["getdata"].inv[0].type == 1)
-
-        # Since we haven't delivered the tx yet, inv'ing the same tx from
-        # a witness transaction ought not result in a getdata.
-        self.test_node.announce_tx_and_wait_for_getdata(tx, timeout=2, success=False)
-
-        # Delivering this transaction with witness should fail (no matter who
-        # its from)
-        assert_equal(len(self.nodes[0].getrawmempool()), 0)
-        assert_equal(len(self.nodes[1].getrawmempool()), 0)
-        test_transaction_acceptance(self.nodes[0].rpc, self.old_node, tx, with_witness=True, accepted=False)
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx, with_witness=True, accepted=False)
-
-        # But eliminating the witness should fix it
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx, with_witness=False, accepted=True)
-
-        # Cleanup: mine the first transaction and update utxo
-        self.nodes[0].generate(1)
-        assert_equal(len(self.nodes[0].getrawmempool()), 0)
-
-        self.utxo.pop(0)
-        self.utxo.append(UTXO(tx_hash, 0, tx_value))
-
     def test_tx_relay_after_segwit_activation(self):
         """Test transaction relay after segwit activation.
 
@@ -1043,185 +1404,9 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
 
-    def test_block_relay(self, segwit_activated):
-        """Test that block requests to NODE_WITNESS peer are with MSG_WITNESS_FLAG.
-
-        This is true regardless of segwit activation.
-        Also test that we don't ask for blocks from unupgraded peers."""
-        self.log.info("Testing block relay")
-
-        blocktype = 2 | MSG_WITNESS_FLAG
-
-        # test_node has set NODE_WITNESS, so all getdata requests should be for
-        # witness blocks.
-        # Test announcing a block via inv results in a getdata, and that
-        # announcing a version 4 or random VB block with a header results in a getdata
-        block1 = self.build_next_block()
-        block1.solve()
-
-        self.test_node.announce_block_and_wait_for_getdata(block1, use_header=False)
-        assert(self.test_node.last_message["getdata"].inv[0].type == blocktype)
-        test_witness_block(self.nodes[0].rpc, self.test_node, block1, True)
-
-        block2 = self.build_next_block(version=4)
-        block2.solve()
-
-        self.test_node.announce_block_and_wait_for_getdata(block2, use_header=True)
-        assert(self.test_node.last_message["getdata"].inv[0].type == blocktype)
-        test_witness_block(self.nodes[0].rpc, self.test_node, block2, True)
-
-        block3 = self.build_next_block(version=(VB_TOP_BITS | (1 << 15)))
-        block3.solve()
-        self.test_node.announce_block_and_wait_for_getdata(block3, use_header=True)
-        assert(self.test_node.last_message["getdata"].inv[0].type == blocktype)
-        test_witness_block(self.nodes[0].rpc, self.test_node, block3, True)
-
-        # Check that we can getdata for witness blocks or regular blocks,
-        # and the right thing happens.
-        if not segwit_activated:
-            # Before activation, we should be able to request old blocks with
-            # or without witness, and they should be the same.
-            chain_height = self.nodes[0].getblockcount()
-            # Pick 10 random blocks on main chain, and verify that getdata's
-            # for MSG_BLOCK, MSG_WITNESS_BLOCK, and rpc getblock() are equal.
-            all_heights = list(range(chain_height + 1))
-            random.shuffle(all_heights)
-            all_heights = all_heights[0:10]
-            for height in all_heights:
-                block_hash = self.nodes[0].getblockhash(height)
-                rpc_block = self.nodes[0].getblock(block_hash, False)
-                block_hash = int(block_hash, 16)
-                block = self.test_node.request_block(block_hash, 2)
-                wit_block = self.test_node.request_block(block_hash, 2 | MSG_WITNESS_FLAG)
-                assert_equal(block.serialize(True), wit_block.serialize(True))
-                assert_equal(block.serialize(), hex_str_to_bytes(rpc_block))
-        else:
-            # After activation, witness blocks and non-witness blocks should
-            # be different.  Verify rpc getblock() returns witness blocks, while
-            # getdata respects the requested type.
-            block = self.build_next_block()
-            self.update_witness_block_with_transactions(block, [])
-            # This gives us a witness commitment.
-            assert(len(block.vtx[0].wit.vtxinwit) == 1)
-            assert(len(block.vtx[0].wit.vtxinwit[0].scriptWitness.stack) == 1)
-            test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
-            # Now try to retrieve it...
-            rpc_block = self.nodes[0].getblock(block.hash, False)
-            non_wit_block = self.test_node.request_block(block.sha256, 2)
-            wit_block = self.test_node.request_block(block.sha256, 2 | MSG_WITNESS_FLAG)
-            assert_equal(wit_block.serialize(True), hex_str_to_bytes(rpc_block))
-            assert_equal(wit_block.serialize(False), non_wit_block.serialize())
-            assert_equal(wit_block.serialize(True), block.serialize(True))
-
-            # Test size, vsize, weight
-            rpc_details = self.nodes[0].getblock(block.hash, True)
-            assert_equal(rpc_details["size"], len(block.serialize(True)))
-            assert_equal(rpc_details["strippedsize"], len(block.serialize(False)))
-            weight = 3 * len(block.serialize(False)) + len(block.serialize(True))
-            assert_equal(rpc_details["weight"], weight)
-
-            # Upgraded node should not ask for blocks from unupgraded
-            block4 = self.build_next_block(version=4)
-            block4.solve()
-            self.old_node.getdataset = set()
-
-            # Blocks can be requested via direct-fetch (immediately upon processing the announcement)
-            # or via parallel download (with an indeterminate delay from processing the announcement)
-            # so to test that a block is NOT requested, we could guess a time period to sleep for,
-            # and then check. We can avoid the sleep() by taking advantage of transaction getdata's
-            # being processed after block getdata's, and announce a transaction as well,
-            # and then check to see if that particular getdata has been received.
-            # Since 0.14, inv's will only be responded to with a getheaders, so send a header
-            # to announce this block.
-            msg = msg_headers()
-            msg.headers = [CBlockHeader(block4)]
-            self.old_node.send_message(msg)
-            self.old_node.announce_tx_and_wait_for_getdata(block4.vtx[0])
-            assert(block4.sha256 not in self.old_node.getdataset)
-
-    def test_standardness_v0(self, segwit_activated):
-        """Test V0 txout standardness.
-        
-        V0 segwit outputs and inputs are always standard.
-        V0 segwit inputs may only be mined after activation, but not before."""
-
-        self.log.info("Testing standardness of v0 outputs (%s activation)" % ("after" if segwit_activated else "before"))
-        assert(len(self.utxo))
-
-        witness_program = CScript([OP_TRUE])
-        witness_hash = sha256(witness_program)
-        script_pubkey = CScript([OP_0, witness_hash])
-
-        p2sh_pubkey = hash160(witness_program)
-        p2sh_script_pubkey = CScript([OP_HASH160, p2sh_pubkey, OP_EQUAL])
-
-        # First prepare a p2sh output (so that spending it will pass standardness)
-        p2sh_tx = CTransaction()
-        p2sh_tx.vin = [CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b"")]
-        p2sh_tx.vout = [CTxOut(self.utxo[0].nValue - 1000, p2sh_script_pubkey)]
-        p2sh_tx.rehash()
-
-        # Mine it on test_node to create the confirmed output.
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, p2sh_tx, with_witness=True, accepted=True)
-        self.nodes[0].generate(1)
-        sync_blocks(self.nodes)
-
-        # Now test standardness of v0 P2WSH outputs.
-        # Start by creating a transaction with two outputs.
-        tx = CTransaction()
-        tx.vin = [CTxIn(COutPoint(p2sh_tx.sha256, 0), CScript([witness_program]))]
-        tx.vout = [CTxOut(p2sh_tx.vout[0].nValue - 10000, script_pubkey)]
-        tx.vout.append(CTxOut(8000, script_pubkey))  # Might burn this later
-        tx.vin[0].nSequence = BIP125_SEQUENCE_NUMBER  # Just to have the option to bump this tx from the mempool
-        tx.rehash()
-
-        # This is always accepted, since the mempool policy is to consider segwit as always active
-        # and thus allow segwit outputs
-        test_transaction_acceptance(self.nodes[1].rpc, self.std_node, tx, with_witness=True, accepted=True)
-
-        # Now create something that looks like a P2PKH output. This won't be spendable.
-        script_pubkey = CScript([OP_0, hash160(witness_hash)])
-        tx2 = CTransaction()
-        # tx was accepted, so we spend the second output.
-        tx2.vin = [CTxIn(COutPoint(tx.sha256, 1), b"")]
-        tx2.vout = [CTxOut(7000, script_pubkey)]
-        tx2.wit.vtxinwit.append(CTxInWitness())
-        tx2.wit.vtxinwit[0].scriptWitness.stack = [witness_program]
-        tx2.rehash()
-
-        test_transaction_acceptance(self.nodes[1].rpc, self.std_node, tx2, with_witness=True, accepted=True)
-
-        # Now update self.utxo for later tests.
-        tx3 = CTransaction()
-        # tx and tx2 were both accepted.  Don't bother trying to reclaim the
-        # P2PKH output; just send tx's first output back to an anyone-can-spend.
-        sync_mempools([self.nodes[0], self.nodes[1]])
-        tx3.vin = [CTxIn(COutPoint(tx.sha256, 0), b"")]
-        tx3.vout = [CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE]))]
-        tx3.wit.vtxinwit.append(CTxInWitness())
-        tx3.wit.vtxinwit[0].scriptWitness.stack = [witness_program]
-        tx3.rehash()
-        if not segwit_activated:
-            # Just check mempool acceptance, but don't add the transaction to the mempool, since witness is disallowed
-            # in blocks and the tx is impossible to mine right now.
-            assert_equal(self.nodes[0].testmempoolaccept([bytes_to_hex_str(tx3.serialize_with_witness())]), [{'txid': tx3.hash, 'allowed': True}])
-            # Create the same output as tx3, but by replacing tx
-            tx3_out = tx3.vout[0]
-            tx3 = tx
-            tx3.vout = [tx3_out]
-            tx3.rehash()
-            assert_equal(self.nodes[0].testmempoolaccept([bytes_to_hex_str(tx3.serialize_with_witness())]), [{'txid': tx3.hash, 'allowed': True}])
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx3, with_witness=True, accepted=True)
-
-        self.nodes[0].generate(1)
-        sync_blocks(self.nodes)
-        self.utxo.pop(0)
-        self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
-        assert_equal(len(self.nodes[1].getrawmempool()), 0)
-
     def test_segwit_versions(self):
         """Test validity of future segwit version transactions.
-        
+
         Future segwit version transactions are non-standard, but valid in blocks.
         Can run this before and after segwit activation."""
 
@@ -1340,6 +1525,113 @@ class SegWitTest(BitcoinTestFramework):
         self.update_witness_block_with_transactions(block2, [spend_tx])
         test_witness_block(self.nodes[0].rpc, self.test_node, block2, accepted=True)
         sync_blocks(self.nodes)
+
+    def test_uncompressed_pubkey(self):
+        """Test uncompressed pubkey validity in segwit transactions.
+
+        Uncompressed pubkeys are no longer supported in default relay policy,
+        but (for now) are still valid in blocks."""
+
+        self.log.info("Testing uncompressed pubkeys")
+        # Segwit transactions using uncompressed pubkeys are not accepted
+        # under default policy, but should still pass consensus.
+        key = CECKey()
+        key.set_secretbytes(b"9")
+        key.set_compressed(False)
+        pubkey = CPubKey(key.get_pubkey())
+        assert_equal(len(pubkey), 65)  # This should be an uncompressed pubkey
+
+        assert(len(self.utxo) > 0)
+        utxo = self.utxo.pop(0)
+
+        # Test 1: P2WPKH
+        # First create a P2WPKH output that uses an uncompressed pubkey
+        pubkeyhash = hash160(pubkey)
+        script_pkh = CScript([OP_0, pubkeyhash])
+        tx = CTransaction()
+        tx.vin.append(CTxIn(COutPoint(utxo.sha256, utxo.n), b""))
+        tx.vout.append(CTxOut(utxo.nValue - 1000, script_pkh))
+        tx.rehash()
+
+        # Confirm it in a block.
+        block = self.build_next_block()
+        self.update_witness_block_with_transactions(block, [tx])
+        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
+
+        # Now try to spend it. Send it to a P2WSH output, which we'll
+        # use in the next test.
+        witness_program = CScript([pubkey, CScriptOp(OP_CHECKSIG)])
+        witness_hash = sha256(witness_program)
+        script_wsh = CScript([OP_0, witness_hash])
+
+        tx2 = CTransaction()
+        tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, script_wsh))
+        script = get_p2pkh_script(pubkeyhash)
+        sig_hash = SegwitVersion1SignatureHash(script, tx2, 0, SIGHASH_ALL, tx.vout[0].nValue)
+        signature = key.sign(sig_hash) + b'\x01'  # 0x1 is SIGHASH_ALL
+        tx2.wit.vtxinwit.append(CTxInWitness())
+        tx2.wit.vtxinwit[0].scriptWitness.stack = [signature, pubkey]
+        tx2.rehash()
+
+        # Should fail policy test.
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx2, True, False, b'non-mandatory-script-verify-flag (Using non-compressed keys in segwit)')
+        # But passes consensus.
+        block = self.build_next_block()
+        self.update_witness_block_with_transactions(block, [tx2])
+        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
+
+        # Test 2: P2WSH
+        # Try to spend the P2WSH output created in last test.
+        # Send it to a P2SH(P2WSH) output, which we'll use in the next test.
+        p2sh_witness_hash = hash160(script_wsh)
+        script_p2sh = CScript([OP_HASH160, p2sh_witness_hash, OP_EQUAL])
+        script_sig = CScript([script_wsh])
+
+        tx3 = CTransaction()
+        tx3.vin.append(CTxIn(COutPoint(tx2.sha256, 0), b""))
+        tx3.vout.append(CTxOut(tx2.vout[0].nValue - 1000, script_p2sh))
+        tx3.wit.vtxinwit.append(CTxInWitness())
+        sign_p2pk_witness_input(witness_program, tx3, 0, SIGHASH_ALL, tx2.vout[0].nValue, key)
+
+        # Should fail policy test.
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx3, True, False, b'non-mandatory-script-verify-flag (Using non-compressed keys in segwit)')
+        # But passes consensus.
+        block = self.build_next_block()
+        self.update_witness_block_with_transactions(block, [tx3])
+        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
+
+        # Test 3: P2SH(P2WSH)
+        # Try to spend the P2SH output created in the last test.
+        # Send it to a P2PKH output, which we'll use in the next test.
+        script_pubkey = get_p2pkh_script(pubkeyhash)
+        tx4 = CTransaction()
+        tx4.vin.append(CTxIn(COutPoint(tx3.sha256, 0), script_sig))
+        tx4.vout.append(CTxOut(tx3.vout[0].nValue - 1000, script_pubkey))
+        tx4.wit.vtxinwit.append(CTxInWitness())
+        sign_p2pk_witness_input(witness_program, tx4, 0, SIGHASH_ALL, tx3.vout[0].nValue, key)
+
+        # Should fail policy test.
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx4, True, False, b'non-mandatory-script-verify-flag (Using non-compressed keys in segwit)')
+        block = self.build_next_block()
+        self.update_witness_block_with_transactions(block, [tx4])
+        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
+
+        # Test 4: Uncompressed pubkeys should still be valid in non-segwit
+        # transactions.
+        tx5 = CTransaction()
+        tx5.vin.append(CTxIn(COutPoint(tx4.sha256, 0), b""))
+        tx5.vout.append(CTxOut(tx4.vout[0].nValue - 1000, CScript([OP_TRUE])))
+        (sig_hash, err) = SignatureHash(script_pubkey, tx5, 0, SIGHASH_ALL)
+        signature = key.sign(sig_hash) + b'\x01'  # 0x1 is SIGHASH_ALL
+        tx5.vin[0].scriptSig = CScript([signature, pubkey])
+        tx5.rehash()
+        # Should pass policy and consensus.
+        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx5, True, True)
+        block = self.build_next_block()
+        self.update_witness_block_with_transactions(block, [tx5])
+        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
+        self.utxo.append(UTXO(tx5.sha256, 0, tx5.vout[0].nValue))
 
     def test_signature_version_1(self):
         self.log.info("Testing segwit signature hash version 1")
@@ -1523,360 +1815,6 @@ class SegWitTest(BitcoinTestFramework):
         for i in range(len(tx.vout)):
             self.utxo.append(UTXO(tx.sha256, i, tx.vout[i].nValue))
 
-    def test_p2sh_witness(self, segwit_activated):
-        """Test P2SH wrapped witness programs."""
-        self.log.info("Testing P2SH witness transactions")
-
-        assert(len(self.utxo))
-
-        # Prepare the p2sh-wrapped witness output
-        witness_program = CScript([OP_DROP, OP_TRUE])
-        witness_hash = sha256(witness_program)
-        p2wsh_pubkey = CScript([OP_0, witness_hash])
-        p2sh_witness_hash = hash160(p2wsh_pubkey)
-        script_pubkey = CScript([OP_HASH160, p2sh_witness_hash, OP_EQUAL])
-        script_sig = CScript([p2wsh_pubkey])  # a push of the redeem script
-
-        # Fund the P2SH output
-        tx = CTransaction()
-        tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, script_pubkey))
-        tx.rehash()
-
-        # Verify mempool acceptance and block validity
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx, with_witness=False, accepted=True)
-        block = self.build_next_block()
-        self.update_witness_block_with_transactions(block, [tx])
-        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True, with_witness=segwit_activated)
-        sync_blocks(self.nodes)
-
-        # Now test attempts to spend the output.
-        spend_tx = CTransaction()
-        spend_tx.vin.append(CTxIn(COutPoint(tx.sha256, 0), script_sig))
-        spend_tx.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE])))
-        spend_tx.rehash()
-
-        # This transaction should not be accepted into the mempool pre- or
-        # post-segwit.  Mempool acceptance will use SCRIPT_VERIFY_WITNESS which
-        # will require a witness to spend a witness program regardless of
-        # segwit activation.  Note that older bitcoind's that are not
-        # segwit-aware would also reject this for failing CLEANSTACK.
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, spend_tx, with_witness=False, accepted=False)
-
-        # Try to put the witness script in the script_sig, should also fail.
-        spend_tx.vin[0].script_sig = CScript([p2wsh_pubkey, b'a'])
-        spend_tx.rehash()
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, spend_tx, with_witness=False, accepted=False)
-
-        # Now put the witness script in the witness, should succeed after
-        # segwit activates.
-        spend_tx.vin[0].scriptSig = script_sig
-        spend_tx.rehash()
-        spend_tx.wit.vtxinwit.append(CTxInWitness())
-        spend_tx.wit.vtxinwit[0].scriptWitness.stack = [b'a', witness_program]
-
-        # Verify mempool acceptance
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, spend_tx, with_witness=True, accepted=segwit_activated)
-        block = self.build_next_block()
-        self.update_witness_block_with_transactions(block, [spend_tx])
-
-        # If we're after activation, then sending this with witnesses should be valid.
-        # This no longer works before activation, because SCRIPT_VERIFY_WITNESS
-        # is always set.
-        # TODO: rewrite this test to make clear that it only works after activation.
-        if segwit_activated:
-            test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
-        else:
-            test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True, with_witness=False)
-
-        # Update self.utxo
-        self.utxo.pop(0)
-        self.utxo.append(UTXO(spend_tx.sha256, 0, spend_tx.vout[0].nValue))
-
-    def test_upgrade_after_activation(self, node_id):
-        """Test the behavior of starting up a segwit-aware node after the softfork has activated."""
-        self.log.info("Testing software upgrade after softfork activation")
-
-        assert(node_id != 0)  # node0 is assumed to be a segwit-active bitcoind
-
-        # Make sure the nodes are all up
-        sync_blocks(self.nodes)
-
-        # Restart with the new binary
-        self.stop_node(node_id)
-        self.start_node(node_id, extra_args=["-vbparams=segwit:0:999999999999"])
-        connect_nodes(self.nodes[0], node_id)
-
-        sync_blocks(self.nodes)
-
-        # Make sure that this peer thinks segwit has activated.
-        assert(get_bip9_status(self.nodes[node_id], 'segwit')['status'] == "active")
-
-        # Make sure this peer's blocks match those of node0.
-        height = self.nodes[node_id].getblockcount()
-        while height >= 0:
-            block_hash = self.nodes[node_id].getblockhash(height)
-            assert_equal(block_hash, self.nodes[0].getblockhash(height))
-            assert_equal(self.nodes[0].getblock(block_hash), self.nodes[node_id].getblock(block_hash))
-            height -= 1
-
-    def test_witness_sigops(self):
-        """Test sigop counting is correct inside witnesses."""
-        self.log.info("Testing sigops limit")
-
-        assert(len(self.utxo))
-
-        # Keep this under MAX_OPS_PER_SCRIPT (201)
-        witness_program = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKMULTISIG] * 5 + [OP_CHECKSIG] * 193 + [OP_ENDIF])
-        witness_hash = sha256(witness_program)
-        script_pubkey = CScript([OP_0, witness_hash])
-
-        sigops_per_script = 20 * 5 + 193 * 1
-        # We'll produce 2 extra outputs, one with a program that would take us
-        # over max sig ops, and one with a program that would exactly reach max
-        # sig ops
-        outputs = (MAX_SIGOP_COST // sigops_per_script) + 2
-        extra_sigops_available = MAX_SIGOP_COST % sigops_per_script
-
-        # We chose the number of checkmultisigs/checksigs to make this work:
-        assert(extra_sigops_available < 100)  # steer clear of MAX_OPS_PER_SCRIPT
-
-        # This script, when spent with the first
-        # N(=MAX_SIGOP_COST//sigops_per_script) outputs of our transaction,
-        # would push us just over the block sigop limit.
-        witness_program_toomany = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKSIG] * (extra_sigops_available + 1) + [OP_ENDIF])
-        witness_hash_toomany = sha256(witness_program_toomany)
-        script_pubkey_toomany = CScript([OP_0, witness_hash_toomany])
-
-        # If we spend this script instead, we would exactly reach our sigop
-        # limit (for witness sigops).
-        witness_program_justright = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKSIG] * (extra_sigops_available) + [OP_ENDIF])
-        witness_hash_justright = sha256(witness_program_justright)
-        script_pubkey_justright = CScript([OP_0, witness_hash_justright])
-
-        # First split our available utxo into a bunch of outputs
-        split_value = self.utxo[0].nValue // outputs
-        tx = CTransaction()
-        tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        for i in range(outputs):
-            tx.vout.append(CTxOut(split_value, script_pubkey))
-        tx.vout[-2].scriptPubKey = script_pubkey_toomany
-        tx.vout[-1].scriptPubKey = script_pubkey_justright
-        tx.rehash()
-
-        block_1 = self.build_next_block()
-        self.update_witness_block_with_transactions(block_1, [tx])
-        test_witness_block(self.nodes[0].rpc, self.test_node, block_1, accepted=True)
-
-        tx2 = CTransaction()
-        # If we try to spend the first n-1 outputs from tx, that should be
-        # too many sigops.
-        total_value = 0
-        for i in range(outputs - 1):
-            tx2.vin.append(CTxIn(COutPoint(tx.sha256, i), b""))
-            tx2.wit.vtxinwit.append(CTxInWitness())
-            tx2.wit.vtxinwit[-1].scriptWitness.stack = [witness_program]
-            total_value += tx.vout[i].nValue
-        tx2.wit.vtxinwit[-1].scriptWitness.stack = [witness_program_toomany]
-        tx2.vout.append(CTxOut(total_value, CScript([OP_TRUE])))
-        tx2.rehash()
-
-        block_2 = self.build_next_block()
-        self.update_witness_block_with_transactions(block_2, [tx2])
-        test_witness_block(self.nodes[0].rpc, self.test_node, block_2, accepted=False)
-
-        # Try dropping the last input in tx2, and add an output that has
-        # too many sigops (contributing to legacy sigop count).
-        checksig_count = (extra_sigops_available // 4) + 1
-        script_pubkey_checksigs = CScript([OP_CHECKSIG] * checksig_count)
-        tx2.vout.append(CTxOut(0, script_pubkey_checksigs))
-        tx2.vin.pop()
-        tx2.wit.vtxinwit.pop()
-        tx2.vout[0].nValue -= tx.vout[-2].nValue
-        tx2.rehash()
-        block_3 = self.build_next_block()
-        self.update_witness_block_with_transactions(block_3, [tx2])
-        test_witness_block(self.nodes[0].rpc, self.test_node, block_3, accepted=False)
-
-        # If we drop the last checksig in this output, the tx should succeed.
-        block_4 = self.build_next_block()
-        tx2.vout[-1].scriptPubKey = CScript([OP_CHECKSIG] * (checksig_count - 1))
-        tx2.rehash()
-        self.update_witness_block_with_transactions(block_4, [tx2])
-        test_witness_block(self.nodes[0].rpc, self.test_node, block_4, accepted=True)
-
-        # Reset the tip back down for the next test
-        sync_blocks(self.nodes)
-        for x in self.nodes:
-            x.invalidateblock(block_4.hash)
-
-        # Try replacing the last input of tx2 to be spending the last
-        # output of tx
-        block_5 = self.build_next_block()
-        tx2.vout.pop()
-        tx2.vin.append(CTxIn(COutPoint(tx.sha256, outputs - 1), b""))
-        tx2.wit.vtxinwit.append(CTxInWitness())
-        tx2.wit.vtxinwit[-1].scriptWitness.stack = [witness_program_justright]
-        tx2.rehash()
-        self.update_witness_block_with_transactions(block_5, [tx2])
-        test_witness_block(self.nodes[0].rpc, self.test_node, block_5, accepted=True)
-
-        # TODO: test p2sh sigop counting
-
-    def test_getblocktemplate_before_lockin(self):
-        self.log.info("Testing getblocktemplate setting of segwit versionbit (before lockin)")
-        # Node0 is segwit aware, node2 is not.
-        for node in [self.nodes[0], self.nodes[2]]:
-            gbt_results = node.getblocktemplate()
-            block_version = gbt_results['version']
-            # If we're not indicating segwit support, we will still be
-            # signalling for segwit activation.
-            assert_equal((block_version & (1 << VB_WITNESS_BIT) != 0), node == self.nodes[0])
-            # If we don't specify the segwit rule, then we won't get a default
-            # commitment.
-            assert('default_witness_commitment' not in gbt_results)
-
-        # Workaround:
-        # Can either change the tip, or change the mempool and wait 5 seconds
-        # to trigger a recomputation of getblocktemplate.
-        txid = int(self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1), 16)
-        # Using mocktime lets us avoid sleep()
-        sync_mempools(self.nodes)
-        self.nodes[0].setmocktime(int(time.time()) + 10)
-        self.nodes[2].setmocktime(int(time.time()) + 10)
-
-        for node in [self.nodes[0], self.nodes[2]]:
-            gbt_results = node.getblocktemplate({"rules": ["segwit"]})
-            block_version = gbt_results['version']
-            if node == self.nodes[2]:
-                # If this is a non-segwit node, we should still not get a witness
-                # commitment, nor a version bit signalling segwit.
-                assert_equal(block_version & (1 << VB_WITNESS_BIT), 0)
-                assert('default_witness_commitment' not in gbt_results)
-            else:
-                # For segwit-aware nodes, check the version bit and the witness
-                # commitment are correct.
-                assert(block_version & (1 << VB_WITNESS_BIT) != 0)
-                assert('default_witness_commitment' in gbt_results)
-                witness_commitment = gbt_results['default_witness_commitment']
-
-                # Check that default_witness_commitment is present.
-                witness_root = CBlock.get_merkle_root([ser_uint256(0),
-                                                       ser_uint256(txid)])
-                script = get_witness_script(witness_root, 0)
-                assert_equal(witness_commitment, bytes_to_hex_str(script))
-
-        # undo mocktime
-        self.nodes[0].setmocktime(0)
-        self.nodes[2].setmocktime(0)
-
-    def test_uncompressed_pubkey(self):
-        """Test uncompressed pubkey validity in segwit transactions.
-
-        Uncompressed pubkeys are no longer supported in default relay policy,
-        but (for now) are still valid in blocks."""
-
-        self.log.info("Testing uncompressed pubkeys")
-        # Segwit transactions using uncompressed pubkeys are not accepted
-        # under default policy, but should still pass consensus.
-        key = CECKey()
-        key.set_secretbytes(b"9")
-        key.set_compressed(False)
-        pubkey = CPubKey(key.get_pubkey())
-        assert_equal(len(pubkey), 65)  # This should be an uncompressed pubkey
-
-        assert(len(self.utxo) > 0)
-        utxo = self.utxo.pop(0)
-
-        # Test 1: P2WPKH
-        # First create a P2WPKH output that uses an uncompressed pubkey
-        pubkeyhash = hash160(pubkey)
-        script_pkh = CScript([OP_0, pubkeyhash])
-        tx = CTransaction()
-        tx.vin.append(CTxIn(COutPoint(utxo.sha256, utxo.n), b""))
-        tx.vout.append(CTxOut(utxo.nValue - 1000, script_pkh))
-        tx.rehash()
-
-        # Confirm it in a block.
-        block = self.build_next_block()
-        self.update_witness_block_with_transactions(block, [tx])
-        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
-
-        # Now try to spend it. Send it to a P2WSH output, which we'll
-        # use in the next test.
-        witness_program = CScript([pubkey, CScriptOp(OP_CHECKSIG)])
-        witness_hash = sha256(witness_program)
-        script_wsh = CScript([OP_0, witness_hash])
-
-        tx2 = CTransaction()
-        tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, script_wsh))
-        script = get_p2pkh_script(pubkeyhash)
-        sig_hash = SegwitVersion1SignatureHash(script, tx2, 0, SIGHASH_ALL, tx.vout[0].nValue)
-        signature = key.sign(sig_hash) + b'\x01'  # 0x1 is SIGHASH_ALL
-        tx2.wit.vtxinwit.append(CTxInWitness())
-        tx2.wit.vtxinwit[0].scriptWitness.stack = [signature, pubkey]
-        tx2.rehash()
-
-        # Should fail policy test.
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx2, True, False, b'non-mandatory-script-verify-flag (Using non-compressed keys in segwit)')
-        # But passes consensus.
-        block = self.build_next_block()
-        self.update_witness_block_with_transactions(block, [tx2])
-        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
-
-        # Test 2: P2WSH
-        # Try to spend the P2WSH output created in last test.
-        # Send it to a P2SH(P2WSH) output, which we'll use in the next test.
-        p2sh_witness_hash = hash160(script_wsh)
-        script_p2sh = CScript([OP_HASH160, p2sh_witness_hash, OP_EQUAL])
-        script_sig = CScript([script_wsh])
-
-        tx3 = CTransaction()
-        tx3.vin.append(CTxIn(COutPoint(tx2.sha256, 0), b""))
-        tx3.vout.append(CTxOut(tx2.vout[0].nValue - 1000, script_p2sh))
-        tx3.wit.vtxinwit.append(CTxInWitness())
-        sign_p2pk_witness_input(witness_program, tx3, 0, SIGHASH_ALL, tx2.vout[0].nValue, key)
-
-        # Should fail policy test.
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx3, True, False, b'non-mandatory-script-verify-flag (Using non-compressed keys in segwit)')
-        # But passes consensus.
-        block = self.build_next_block()
-        self.update_witness_block_with_transactions(block, [tx3])
-        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
-
-        # Test 3: P2SH(P2WSH)
-        # Try to spend the P2SH output created in the last test.
-        # Send it to a P2PKH output, which we'll use in the next test.
-        script_pubkey = get_p2pkh_script(pubkeyhash)
-        tx4 = CTransaction()
-        tx4.vin.append(CTxIn(COutPoint(tx3.sha256, 0), script_sig))
-        tx4.vout.append(CTxOut(tx3.vout[0].nValue - 1000, script_pubkey))
-        tx4.wit.vtxinwit.append(CTxInWitness())
-        sign_p2pk_witness_input(witness_program, tx4, 0, SIGHASH_ALL, tx3.vout[0].nValue, key)
-
-        # Should fail policy test.
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx4, True, False, b'non-mandatory-script-verify-flag (Using non-compressed keys in segwit)')
-        block = self.build_next_block()
-        self.update_witness_block_with_transactions(block, [tx4])
-        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
-
-        # Test 4: Uncompressed pubkeys should still be valid in non-segwit
-        # transactions.
-        tx5 = CTransaction()
-        tx5.vin.append(CTxIn(COutPoint(tx4.sha256, 0), b""))
-        tx5.vout.append(CTxOut(tx4.vout[0].nValue - 1000, CScript([OP_TRUE])))
-        (sig_hash, err) = SignatureHash(script_pubkey, tx5, 0, SIGHASH_ALL)
-        signature = key.sign(sig_hash) + b'\x01'  # 0x1 is SIGHASH_ALL
-        tx5.vin[0].scriptSig = CScript([signature, pubkey])
-        tx5.rehash()
-        # Should pass policy and consensus.
-        test_transaction_acceptance(self.nodes[0].rpc, self.test_node, tx5, True, True)
-        block = self.build_next_block()
-        self.update_witness_block_with_transactions(block, [tx5])
-        test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
-        self.utxo.append(UTXO(tx5.sha256, 0, tx5.vout[0].nValue))
-
     def test_non_standard_witness_blinding(self):
         self.log.info("Testing behavior of unnecessary witnesses in transactions does not blind the node for the transaction")
         assert (len(self.utxo) > 0)
@@ -2031,76 +1969,135 @@ class SegWitTest(BitcoinTestFramework):
 
         self.utxo.pop(0)
 
-    def run_test(self):
-        # Setup the p2p connections
-        # self.test_node sets NODE_WITNESS|NODE_NETWORK
-        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK | NODE_WITNESS)
-        # self.old_node sets only NODE_NETWORK
-        self.old_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
-        # self.std_node is for testing node1 (fRequireStandard=true)
-        self.std_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK | NODE_WITNESS)
+    def test_upgrade_after_activation(self, node_id):
+        """Test the behavior of starting up a segwit-aware node after the softfork has activated."""
+        self.log.info("Testing software upgrade after softfork activation")
 
-        # Keep a place to store utxo's that can be used in later tests
-        self.utxo = []
+        assert(node_id != 0)  # node0 is assumed to be a segwit-active bitcoind
 
-        # Test logic begins here
-        self.test_node.wait_for_verack()
-
-        self.log.info("Starting tests before segwit lock in:")
-
-        self.test_witness_services()  # Verifies NODE_WITNESS
-        self.test_non_witness_transaction()  # non-witness tx's are accepted
-        self.test_unnecessary_witness_before_segwit_activation()
-        self.test_v0_outputs_arent_spendable()
-        self.test_block_relay(segwit_activated=False)
-
-        # Advance to segwit being 'started'
-        self.advance_to_segwit_started()
+        # Make sure the nodes are all up
         sync_blocks(self.nodes)
-        self.test_getblocktemplate_before_lockin()
+
+        # Restart with the new binary
+        self.stop_node(node_id)
+        self.start_node(node_id, extra_args=["-vbparams=segwit:0:999999999999"])
+        connect_nodes(self.nodes[0], node_id)
 
         sync_blocks(self.nodes)
 
-        # At lockin, nothing should change.
-        self.log.info("Testing behavior post lockin, pre-activation")
-        self.advance_to_segwit_lockin()
+        # Make sure that this peer thinks segwit has activated.
+        assert(get_bip9_status(self.nodes[node_id], 'segwit')['status'] == "active")
 
-        # Retest unnecessary witnesses
-        self.test_unnecessary_witness_before_segwit_activation()
-        self.test_witness_tx_relay_before_segwit_activation()
-        self.test_block_relay(segwit_activated=False)
-        self.test_standardness_v0(segwit_activated=False)
+        # Make sure this peer's blocks match those of node0.
+        height = self.nodes[node_id].getblockcount()
+        while height >= 0:
+            block_hash = self.nodes[node_id].getblockhash(height)
+            assert_equal(block_hash, self.nodes[0].getblockhash(height))
+            assert_equal(self.nodes[0].getblock(block_hash), self.nodes[node_id].getblock(block_hash))
+            height -= 1
 
+    def test_witness_sigops(self):
+        """Test sigop counting is correct inside witnesses."""
+        self.log.info("Testing sigops limit")
+
+        assert(len(self.utxo))
+
+        # Keep this under MAX_OPS_PER_SCRIPT (201)
+        witness_program = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKMULTISIG] * 5 + [OP_CHECKSIG] * 193 + [OP_ENDIF])
+        witness_hash = sha256(witness_program)
+        script_pubkey = CScript([OP_0, witness_hash])
+
+        sigops_per_script = 20 * 5 + 193 * 1
+        # We'll produce 2 extra outputs, one with a program that would take us
+        # over max sig ops, and one with a program that would exactly reach max
+        # sig ops
+        outputs = (MAX_SIGOP_COST // sigops_per_script) + 2
+        extra_sigops_available = MAX_SIGOP_COST % sigops_per_script
+
+        # We chose the number of checkmultisigs/checksigs to make this work:
+        assert(extra_sigops_available < 100)  # steer clear of MAX_OPS_PER_SCRIPT
+
+        # This script, when spent with the first
+        # N(=MAX_SIGOP_COST//sigops_per_script) outputs of our transaction,
+        # would push us just over the block sigop limit.
+        witness_program_toomany = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKSIG] * (extra_sigops_available + 1) + [OP_ENDIF])
+        witness_hash_toomany = sha256(witness_program_toomany)
+        script_pubkey_toomany = CScript([OP_0, witness_hash_toomany])
+
+        # If we spend this script instead, we would exactly reach our sigop
+        # limit (for witness sigops).
+        witness_program_justright = CScript([OP_TRUE, OP_IF, OP_TRUE, OP_ELSE] + [OP_CHECKSIG] * (extra_sigops_available) + [OP_ENDIF])
+        witness_hash_justright = sha256(witness_program_justright)
+        script_pubkey_justright = CScript([OP_0, witness_hash_justright])
+
+        # First split our available utxo into a bunch of outputs
+        split_value = self.utxo[0].nValue // outputs
+        tx = CTransaction()
+        tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
+        for i in range(outputs):
+            tx.vout.append(CTxOut(split_value, script_pubkey))
+        tx.vout[-2].scriptPubKey = script_pubkey_toomany
+        tx.vout[-1].scriptPubKey = script_pubkey_justright
+        tx.rehash()
+
+        block_1 = self.build_next_block()
+        self.update_witness_block_with_transactions(block_1, [tx])
+        test_witness_block(self.nodes[0].rpc, self.test_node, block_1, accepted=True)
+
+        tx2 = CTransaction()
+        # If we try to spend the first n-1 outputs from tx, that should be
+        # too many sigops.
+        total_value = 0
+        for i in range(outputs - 1):
+            tx2.vin.append(CTxIn(COutPoint(tx.sha256, i), b""))
+            tx2.wit.vtxinwit.append(CTxInWitness())
+            tx2.wit.vtxinwit[-1].scriptWitness.stack = [witness_program]
+            total_value += tx.vout[i].nValue
+        tx2.wit.vtxinwit[-1].scriptWitness.stack = [witness_program_toomany]
+        tx2.vout.append(CTxOut(total_value, CScript([OP_TRUE])))
+        tx2.rehash()
+
+        block_2 = self.build_next_block()
+        self.update_witness_block_with_transactions(block_2, [tx2])
+        test_witness_block(self.nodes[0].rpc, self.test_node, block_2, accepted=False)
+
+        # Try dropping the last input in tx2, and add an output that has
+        # too many sigops (contributing to legacy sigop count).
+        checksig_count = (extra_sigops_available // 4) + 1
+        script_pubkey_checksigs = CScript([OP_CHECKSIG] * checksig_count)
+        tx2.vout.append(CTxOut(0, script_pubkey_checksigs))
+        tx2.vin.pop()
+        tx2.wit.vtxinwit.pop()
+        tx2.vout[0].nValue -= tx.vout[-2].nValue
+        tx2.rehash()
+        block_3 = self.build_next_block()
+        self.update_witness_block_with_transactions(block_3, [tx2])
+        test_witness_block(self.nodes[0].rpc, self.test_node, block_3, accepted=False)
+
+        # If we drop the last checksig in this output, the tx should succeed.
+        block_4 = self.build_next_block()
+        tx2.vout[-1].scriptPubKey = CScript([OP_CHECKSIG] * (checksig_count - 1))
+        tx2.rehash()
+        self.update_witness_block_with_transactions(block_4, [tx2])
+        test_witness_block(self.nodes[0].rpc, self.test_node, block_4, accepted=True)
+
+        # Reset the tip back down for the next test
         sync_blocks(self.nodes)
+        for x in self.nodes:
+            x.invalidateblock(block_4.hash)
 
-        # Now activate segwit
-        self.log.info("Testing behavior after segwit activation")
-        self.advance_to_segwit_active()
+        # Try replacing the last input of tx2 to be spending the last
+        # output of tx
+        block_5 = self.build_next_block()
+        tx2.vout.pop()
+        tx2.vin.append(CTxIn(COutPoint(tx.sha256, outputs - 1), b""))
+        tx2.wit.vtxinwit.append(CTxInWitness())
+        tx2.wit.vtxinwit[-1].scriptWitness.stack = [witness_program_justright]
+        tx2.rehash()
+        self.update_witness_block_with_transactions(block_5, [tx2])
+        test_witness_block(self.nodes[0].rpc, self.test_node, block_5, accepted=True)
 
-        sync_blocks(self.nodes)
-
-        # Test P2SH witness handling again
-        self.test_p2sh_witness(segwit_activated=True)
-        self.test_witness_commitments()
-        self.test_block_malleability()
-        self.test_witness_block_size()
-        self.test_submit_block()
-        self.test_extra_witness_data()
-        self.test_max_witness_push_length()
-        self.test_max_witness_program_length()
-        self.test_witness_input_length()
-        self.test_block_relay(segwit_activated=True)
-        self.test_tx_relay_after_segwit_activation()
-        self.test_standardness_v0(segwit_activated=True)
-        self.test_segwit_versions()
-        self.test_premature_coinbase_witness_spend()
-        self.test_uncompressed_pubkey()
-        self.test_signature_version_1()
-        self.test_non_standard_witness_blinding()
-        self.test_non_standard_witness()
-        sync_blocks(self.nodes)
-        self.test_upgrade_after_activation(node_id=2)
-        self.test_witness_sigops()
+        # TODO: test p2sh sigop counting
 
 if __name__ == '__main__':
     SegWitTest().main()

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -293,15 +293,24 @@ class SegWitTest(BitcoinTestFramework):
 
     # Individual tests
 
+    def subtest(func):  # noqa: N805
+        """Wraps the subtests for logging and state assertions."""
+        def func_wrapper(self, *args, **kwargs):
+            self.log.info("Subtest: {}".format(func.__name__))
+            func(self, *args, **kwargs)
+
+        return func_wrapper
+
     def test_witness_services(self):
         self.log.info("Verifying NODE_WITNESS service bit")
         assert((self.test_node.nServices & NODE_WITNESS) != 0)
 
+    @subtest
     def test_non_witness_transaction(self):
         """See if sending a regular transaction works, and create a utxo to use in later tests."""
         # Mine a block with an anyone-can-spend coinbase,
         # let it mature, then try to spend it.
-        self.log.info("Testing non-witness transaction")
+
         block = self.build_next_block(version=1)
         block.solve()
         self.test_node.send_message(msg_block(block))
@@ -327,9 +336,10 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.append(UTXO(tx.sha256, 0, 49 * 100000000))
         self.nodes[0].generate(1)
 
+    @subtest
     def test_unnecessary_witness_before_segwit_activation(self):
         """Verify that blocks with witnesses are rejected before activation."""
-        self.log.info("Testing behavior of unnecessary witnesses")
+
         # For now, rely on earlier tests to have created at least one utxo for
         # us to use
         assert(len(self.utxo) > 0)
@@ -369,12 +379,12 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx.sha256, 0, tx.vout[0].nValue))
 
+    @subtest
     def test_block_relay(self, segwit_activated):
         """Test that block requests to NODE_WITNESS peer are with MSG_WITNESS_FLAG.
 
         This is true regardless of segwit activation.
         Also test that we don't ask for blocks from unupgraded peers."""
-        self.log.info("Testing block relay")
 
         blocktype = 2 | MSG_WITNESS_FLAG
 
@@ -465,6 +475,7 @@ class SegWitTest(BitcoinTestFramework):
             self.old_node.announce_tx_and_wait_for_getdata(block4.vtx[0])
             assert(block4.sha256 not in self.old_node.getdataset)
 
+    @subtest
     def test_v0_outputs_arent_spendable(self):
         """Test that v0 outputs aren't spendable before segwit activation.
 
@@ -475,8 +486,6 @@ class SegWitTest(BitcoinTestFramework):
         Consequently, version 0 witness outputs are never spendable without
         witness, and so can't be spent before segwit activation (the point at which
         blocks are permitted to contain witnesses)."""
-
-        self.log.info("Testing that v0 witness program outputs aren't spendable before activation")
 
         assert len(self.utxo), "self.utxo is empty"
 
@@ -543,6 +552,7 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(txid, 2, value))
 
+    @subtest
     def advance_to_segwit_started(self):
         """Mine enough blocks for segwit's vb state to be 'started'."""
         height = self.nodes[0].getblockcount()
@@ -554,8 +564,8 @@ class SegWitTest(BitcoinTestFramework):
         self.nodes[0].generate(VB_PERIOD - height - 1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'started')
 
+    @subtest
     def test_getblocktemplate_before_lockin(self):
-        self.log.info("Testing getblocktemplate setting of segwit versionbit (before lockin)")
         # Node0 is segwit aware, node2 is not.
         for node in [self.nodes[0], self.nodes[2]]:
             gbt_results = node.getblocktemplate()
@@ -601,6 +611,7 @@ class SegWitTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(0)
         self.nodes[2].setmocktime(0)
 
+    @subtest
     def advance_to_segwit_lockin(self):
         """Mine enough blocks to lock in segwit, but don't activate."""
         # TODO: we could verify that lockin only happens at the right threshold of
@@ -616,8 +627,9 @@ class SegWitTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
 
+    @subtest
     def test_witness_tx_relay_before_segwit_activation(self):
-        self.log.info("Testing relay of witness transactions")
+
         # Generate a transaction that doesn't require a witness, but send it
         # with a witness.  Should be rejected for premature-witness, but should
         # not be added to recently rejected list.
@@ -658,13 +670,13 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx_hash, 0, tx_value))
 
+    @subtest
     def test_standardness_v0(self, segwit_activated):
         """Test V0 txout standardness.
 
         V0 segwit outputs and inputs are always standard.
         V0 segwit inputs may only be mined after activation, but not before."""
 
-        self.log.info("Testing standardness of v0 outputs (%s activation)" % ("after" if segwit_activated else "before"))
         assert(len(self.utxo))
 
         witness_program = CScript([OP_TRUE])
@@ -738,6 +750,7 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
         assert_equal(len(self.nodes[1].getrawmempool()), 0)
 
+    @subtest
     def advance_to_segwit_active(self):
         """Mine enough blocks to activate segwit."""
         # TODO: we could verify that activation only happens at the right threshold
@@ -750,9 +763,9 @@ class SegWitTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'active')
 
+    @subtest
     def test_p2sh_witness(self, segwit_activated):
         """Test P2SH wrapped witness programs."""
-        self.log.info("Testing P2SH witness transactions")
 
         assert(len(self.utxo))
 
@@ -820,12 +833,11 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(spend_tx.sha256, 0, spend_tx.vout[0].nValue))
 
+    @subtest
     def test_witness_commitments(self):
         """Test witness commitments.
 
         This test can only be run after segwit has activated."""
-
-        self.log.info("Testing witness commitments")
 
         # First try a correct witness commitment.
         block = self.build_next_block()
@@ -912,8 +924,8 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
 
+    @subtest
     def test_block_malleability(self):
-        self.log.info("Testing witness block malleability")
 
         # Make sure that a block that has too big a virtual size
         # because of a too-large coinbase witness is not permanently
@@ -952,8 +964,8 @@ class SegWitTest(BitcoinTestFramework):
         block.vtx[0].wit.vtxinwit[0].scriptWitness.stack = [ser_uint256(0)]
         test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
 
+    @subtest
     def test_witness_block_size(self):
-        self.log.info("Testing witness block size limit")
         # TODO: Test that non-witness carrying blocks can't exceed 1MB
         # Skipping this test for now; this is covered in p2p-fullblocktest.py
 
@@ -1030,6 +1042,7 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(block.vtx[-1].sha256, 0, block.vtx[-1].vout[0].nValue))
 
+    @subtest
     def test_submit_block(self):
         """Test that submitblock adds the nonce automatically when possible."""
         block = self.build_next_block()
@@ -1065,9 +1078,9 @@ class SegWitTest(BitcoinTestFramework):
         # Tip should not advance!
         assert(self.nodes[0].getbestblockhash() != block_2.hash)
 
+    @subtest
     def test_extra_witness_data(self):
         """Test extra witness data in a transaction."""
-        self.log.info("Testing extra witness data in tx")
 
         assert(len(self.utxo) > 0)
 
@@ -1140,9 +1153,10 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx2.sha256, 0, tx2.vout[0].nValue))
 
+    @subtest
     def test_max_witness_push_length(self):
         """Test that witness stack can only allow up to 520 byte pushes."""
-        self.log.info("Testing maximum witness push size")
+
         MAX_SCRIPT_ELEMENT_SIZE = 520
         assert(len(self.utxo))
 
@@ -1179,9 +1193,10 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop()
         self.utxo.append(UTXO(tx2.sha256, 0, tx2.vout[0].nValue))
 
+    @subtest
     def test_max_witness_program_length(self):
         """Test that witness outputs greater than 10kB can't be spent."""
-        self.log.info("Testing maximum witness program length")
+
         assert(len(self.utxo))
         MAX_PROGRAM_LENGTH = 10000
 
@@ -1227,9 +1242,10 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop()
         self.utxo.append(UTXO(tx2.sha256, 0, tx2.vout[0].nValue))
 
+    @subtest
     def test_witness_input_length(self):
         """Test that vin length must match vtxinwit length."""
-        self.log.info("Testing witness input length")
+
         assert(len(self.utxo))
 
         witness_program = CScript([OP_DROP, OP_TRUE])
@@ -1310,6 +1326,7 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop()
         self.utxo.append(UTXO(tx2.sha256, 0, tx2.vout[0].nValue))
 
+    @subtest
     def test_tx_relay_after_segwit_activation(self):
         """Test transaction relay after segwit activation.
 
@@ -1318,7 +1335,6 @@ class SegWitTest(BitcoinTestFramework):
         - accepts transactions with valid witnesses
         and that witness transactions are relayed to non-upgraded peers."""
 
-        self.log.info("Testing relay of witness transactions")
         # Generate a transaction that doesn't require a witness, but send it
         # with a witness.  Should be rejected because we can't use a witness
         # when spending a non-witness output.
@@ -1404,13 +1420,13 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
 
+    @subtest
     def test_segwit_versions(self):
         """Test validity of future segwit version transactions.
 
         Future segwit version transactions are non-standard, but valid in blocks.
         Can run this before and after segwit activation."""
 
-        self.log.info("Testing standardness/consensus for segwit versions (0-16)")
         assert(len(self.utxo))
         num_tests = 17  # will test OP_0, OP1, ..., OP_16
         if (len(self.utxo) < num_tests):
@@ -1492,8 +1508,9 @@ class SegWitTest(BitcoinTestFramework):
         # Add utxo to our list
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
 
+    @subtest
     def test_premature_coinbase_witness_spend(self):
-        self.log.info("Testing premature coinbase witness spend")
+
         block = self.build_next_block()
         # Change the output of the block to be a witness output.
         witness_program = CScript([OP_TRUE])
@@ -1526,13 +1543,13 @@ class SegWitTest(BitcoinTestFramework):
         test_witness_block(self.nodes[0].rpc, self.test_node, block2, accepted=True)
         sync_blocks(self.nodes)
 
+    @subtest
     def test_uncompressed_pubkey(self):
         """Test uncompressed pubkey validity in segwit transactions.
 
         Uncompressed pubkeys are no longer supported in default relay policy,
         but (for now) are still valid in blocks."""
 
-        self.log.info("Testing uncompressed pubkeys")
         # Segwit transactions using uncompressed pubkeys are not accepted
         # under default policy, but should still pass consensus.
         key = CECKey()
@@ -1633,8 +1650,9 @@ class SegWitTest(BitcoinTestFramework):
         test_witness_block(self.nodes[0].rpc, self.test_node, block, accepted=True)
         self.utxo.append(UTXO(tx5.sha256, 0, tx5.vout[0].nValue))
 
+    @subtest
     def test_signature_version_1(self):
-        self.log.info("Testing segwit signature hash version 1")
+
         key = CECKey()
         key.set_secretbytes(b"9")
         pubkey = CPubKey(key.get_pubkey())
@@ -1815,8 +1833,9 @@ class SegWitTest(BitcoinTestFramework):
         for i in range(len(tx.vout)):
             self.utxo.append(UTXO(tx.sha256, i, tx.vout[i].nValue))
 
+    @subtest
     def test_non_standard_witness_blinding(self):
-        self.log.info("Testing behavior of unnecessary witnesses in transactions does not blind the node for the transaction")
+        """Test behavior of unnecessary witnesses in transactions does not blind the node for the transaction"""
         assert (len(self.utxo) > 0)
 
         # Create a p2sh output -- this is so we can pass the standardness
@@ -1869,8 +1888,9 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
 
+    @subtest
     def test_non_standard_witness(self):
-        self.log.info("Testing detection of non-standard P2WSH witness")
+        """Test detection of non-standard P2WSH witness"""
         pad = chr(1).encode('latin-1')
 
         # Create scripts for tests
@@ -1969,9 +1989,9 @@ class SegWitTest(BitcoinTestFramework):
 
         self.utxo.pop(0)
 
+    @subtest
     def test_upgrade_after_activation(self, node_id):
         """Test the behavior of starting up a segwit-aware node after the softfork has activated."""
-        self.log.info("Testing software upgrade after softfork activation")
 
         assert(node_id != 0)  # node0 is assumed to be a segwit-active bitcoind
 
@@ -1996,9 +2016,9 @@ class SegWitTest(BitcoinTestFramework):
             assert_equal(self.nodes[0].getblock(block_hash), self.nodes[node_id].getblock(block_hash))
             height -= 1
 
+    @subtest
     def test_witness_sigops(self):
         """Test sigop counting is correct inside witnesses."""
-        self.log.info("Testing sigops limit")
 
         assert(len(self.utxo))
 


### PR DESCRIPTION
`p2p_segwit.py` is a very long test, composed of multiple subtests. When it fails it's difficult to debug for a couple of reasons:

- Control flow jumps between different methods in the test class, so it's a little difficult to follow the code.
- state may be carried forward unintentionally from one subtest to the next.

Improve that by wrapping the subtests with a `@subtest` decorator which:
- logs progress
- asserts state after each subtest

As usual, I've also included a few commits which generally tidy up the test and improve style.
