### PR TITLE
[build] Tune wildcards for LIBSECP256K1 target

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,7 +53,7 @@ LIBBITCOIN_CRYPTO_AVX2 = crypto/libbitcoin_crypto_avx2.a
 LIBBITCOIN_CRYPTO += $(LIBBITCOIN_CRYPTO_AVX2)
 endif
 
-$(LIBSECP256K1): $(wildcard secp256k1/src/*) $(wildcard secp256k1/include/*)
+$(LIBSECP256K1): $(wildcard secp256k1/src/*.h) $(wildcard secp256k1/src/*.c) $(wildcard secp256k1/include/*)
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D) $(@F)
 
 # Make is not made aware of per-object dependencies to avoid limiting building parallelization


### PR DESCRIPTION
Automake would think the target was out of date every time because e.g. '.deps' was updated.