### PR TITLE
Refactors `keystore.h` type aliases.

### DIFF
--- a/src/keystore.h
+++ b/src/keystore.h
@@ -38,16 +38,16 @@ public:
     virtual bool HaveWatchOnly() const =0;
 };
 
-typedef std::map<CKeyID, CKey> KeyMap;
-typedef std::map<CKeyID, CPubKey> WatchKeyMap;
-typedef std::map<CScriptID, CScript > ScriptMap;
-typedef std::set<CScript> WatchOnlySet;
-
 /** Basic key store, that keeps keys in an address->secret map */
 class CBasicKeyStore : public CKeyStore
 {
 protected:
     mutable CCriticalSection cs_KeyStore;
+
+    using KeyMap = std::map<CKeyID, CKey>;
+    using WatchKeyMap = std::map<CKeyID, CPubKey>;
+    using ScriptMap = std::map<CScriptID, CScript>;
+    using WatchOnlySet = std::set<CScript>;
 
     KeyMap mapKeys GUARDED_BY(cs_KeyStore);
     WatchKeyMap mapWatchKeys GUARDED_BY(cs_KeyStore);
@@ -73,9 +73,6 @@ public:
     bool HaveWatchOnly(const CScript &dest) const override;
     bool HaveWatchOnly() const override;
 };
-
-typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;
-typedef std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char> > > CryptedKeyMap;
 
 /** Return the CKeyID of the key involved in a script (if there is a unique one). */
 CKeyID GetKeyForDestination(const CKeyStore& store, const CTxDestination& dest);

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -132,6 +132,8 @@ private:
     bool fOnlyMixingAllowed;
 
 protected:
+    using CryptedKeyMap = std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char>>>;
+
     bool SetCrypted();
 
     //! will encrypt previously unencrypted keys


### PR DESCRIPTION
This squashed commit either encapsulates type alias declarations at the appropriate scope; or removes type aliases that are not used.

The encapsulated type aliases are declared using C++11's `using` notation in favor of the `typedef` notation.