### PR TITLE
[tests] skip rpc_zmq functional test when python3 zmq lib is not present

### DIFF
--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -3,10 +3,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the ZMQ notification interface."""
-import configparser
 import struct
 
-from test_framework.test_framework import BitcoinTestFramework, SkipTest
+from test_framework.test_framework import (
+    BitcoinTestFramework, skip_if_no_bitcoind_zmq, skip_if_no_py3_zmq)
 from test_framework.mininode import CTransaction
 from test_framework.util import (assert_equal,
                                  bytes_to_hex_str,
@@ -40,18 +40,9 @@ class ZMQTest (BitcoinTestFramework):
         self.num_nodes = 2
 
     def setup_nodes(self):
-        # Try to import python3-zmq. Skip this test if the import fails.
-        try:
-            import zmq
-        except ImportError:
-            raise SkipTest("python3-zmq module not available.")
-
-        # Check that bitcoin has been built with ZMQ enabled.
-        config = configparser.ConfigParser()
-        config.read_file(open(self.options.configfile))
-
-        if not config["components"].getboolean("ENABLE_ZMQ"):
-            raise SkipTest("bitcoind has not been built with zmq enabled.")
+        skip_if_no_py3_zmq()
+        skip_if_no_bitcoind_zmq(self)
+        import zmq
 
         # Initialize ZMQ context and socket.
         # All messages are received in the same socket which means

--- a/test/functional/rpc_zmq.py
+++ b/test/functional/rpc_zmq.py
@@ -4,7 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test for the ZMQ RPC methods."""
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import (
+    BitcoinTestFramework, skip_if_no_py3_zmq, skip_if_no_bitcoind_zmq)
 from test_framework.util import assert_equal
 
 
@@ -17,6 +18,8 @@ class RPCZMQTest(BitcoinTestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
+        skip_if_no_py3_zmq()
+        skip_if_no_bitcoind_zmq(self)
         self._test_getzmqnotifications()
 
     def _test_getzmqnotifications(self):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -475,3 +475,20 @@ class SkipTest(Exception):
     """This exception is raised to skip a test"""
     def __init__(self, message):
         self.message = message
+
+
+def skip_if_no_py3_zmq():
+    """Attempt to import the zmq package and skip the test if the import fails."""
+    try:
+        import zmq  # noqa
+    except ImportError:
+        raise SkipTest("python3-zmq module not available.")
+
+
+def skip_if_no_bitcoind_zmq(test_instance):
+    """Skip the running test if bitcoind has not been compiled with zmq support."""
+    config = configparser.ConfigParser()
+    config.read_file(open(test_instance.options.configfile))
+
+    if not config["components"].getboolean("ENABLE_ZMQ"):
+        raise SkipTest("bitcoind has not been built with zmq enabled.")


### PR DESCRIPTION
Also refactors zmq-related test skipping logic into distinct functions.