### PR TITLE
doc: Add release notes for -printtoconsole and -debuglogfile changes

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -533,6 +533,11 @@ Low-level RPC changes
 
 - The log timestamp format is now ISO 8601 (e.g. "2018-02-28T12:34:56Z").
 
+- When running bitcoind with `-debug` but without `-daemon`, logging to stdout
+  is now the default behavior. Setting `-printtoconsole=1` no longer implicitly
+  disables logging to debug.log. Instead, logging to file can be explicitly disabled
+  by setting `-debuglogfile=0`.
+
 Miner block size removed
 
 The `-blockmaxsize` option for miners to limit their blocks' sizes was


### PR DESCRIPTION
This adds release notes relevant to the changes in #13004 and documented in command line help in #13614