### PR TITLE
Decouple wallet version from client version

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4948,7 +4948,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
         if (nMaxVersion == 0) // the -upgradewallet without argument case
         {
             LogPrintf("Performing wallet upgrade to %i\n", FEATURE_LATEST);
-            nMaxVersion = CLIENT_VERSION;
+            nMaxVersion = FEATURE_LATEST;
             walletInstance->SetMinVersion(FEATURE_LATEST); // permanently upgrade the wallet immediately
         }
         else

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -537,7 +537,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         int nMinVersion = 0;
         if (m_batch.Read((std::string)"minversion", nMinVersion))
         {
-            if (nMinVersion > CLIENT_VERSION)
+            if (nMinVersion > FEATURE_LATEST)
                 return DBErrors::TOO_NEW;
             pwallet->LoadMinVersion(nMinVersion);
         }
@@ -644,7 +644,7 @@ DBErrors WalletBatch::FindWalletTx(std::vector<uint256>& vTxHash, std::vector<CW
         int nMinVersion = 0;
         if (m_batch.Read((std::string)"minversion", nMinVersion))
         {
-            if (nMinVersion > CLIENT_VERSION)
+            if (nMinVersion > FEATURE_LATEST)
                 return DBErrors::TOO_NEW;
         }
 


### PR DESCRIPTION
Instead of comparing version numbers in the wallet to the client
version number, compare them to the latest supported wallet version
in the client. This allows for wallet version numbers to be unrelated
to the client version number.