### PR TITLE
tests: fixes mininode's P2PConnection sending messages on closing tra…

### DIFF
--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -179,7 +179,7 @@ class P2PConnection(asyncio.Protocol):
             raise IOError('Not connected')
         self._log_message("send", message)
         tmsg = self._build_message(message)
-        NetworkThread.network_event_loop.call_soon_threadsafe(lambda: self._transport and self._transport.write(tmsg))
+        NetworkThread.network_event_loop.call_soon_threadsafe(lambda: self._transport and not self._transport.is_closing() and self._transport.write(tmsg))
 
     # Class utility methods
 


### PR DESCRIPTION
…nsport

- checks if  _transport.is_closing() (added in python3.4.4/python3.5.1)
before attempting to send messages on P2PConnection's send_message
method.