### PR TITLE
Removes the boost/algorithm/string/join dependency

### DIFF
--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -49,7 +49,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/algorithm/string.hpp
     boost/algorithm/string/case_conv.hpp
     boost/algorithm/string/classification.hpp
-    boost/algorithm/string/join.hpp
     boost/algorithm/string/predicate.hpp
     boost/algorithm/string/replace.hpp
     boost/algorithm/string/split.hpp


### PR DESCRIPTION
This commit removes the `boost/algorithm/string/join` dependency
from the project by replacing `boost::algorithm::join` with
a simple helper function.