### PR TITLE
wallet: Avoid potential null pointer dereference in CWalletTx::GetAva…

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2127,6 +2127,7 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache, const isminefilter& filter
 
     if (cache) {
         *cache = nCredit;
+        assert(cache_used);
         *cache_used = true;
     }
     return nCredit;


### PR DESCRIPTION
…ilableCredit(...)