### PR TITLE
tiny refactor for ArgsManager

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -464,7 +464,7 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
 
         // Check that the arg is known
         if (!(IsSwitchChar(key[0]) && key.size() == 1)) {
-            if (!IsArgKnown(key, error)) {
+            if (!IsArgKnown(key)) {
                 error = strprintf("Invalid parameter %s", key.c_str());
                 return false;
             }
@@ -484,7 +484,7 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
     return true;
 }
 
-bool ArgsManager::IsArgKnown(const std::string& key, std::string& error)
+bool ArgsManager::IsArgKnown(const std::string& key) const
 {
     size_t option_index = key.find('.');
     std::string arg_no_net;
@@ -609,7 +609,7 @@ void ArgsManager::AddHiddenArgs(const std::vector<std::string>& names)
     }
 }
 
-std::string ArgsManager::GetHelpMessage()
+std::string ArgsManager::GetHelpMessage() const
 {
     const bool show_debug = gArgs.GetBoolArg("-help-debug", false);
 
@@ -885,7 +885,7 @@ bool ArgsManager::ReadConfigStream(std::istream& stream, std::string& error, boo
         }
 
         // Check that the arg is known
-        if (!IsArgKnown(strKey, error) && !ignore_invalid_keys) {
+        if (!IsArgKnown(strKey) && !ignore_invalid_keys) {
             error = strprintf("Invalid configuration value %s", option.first.c_str());
             return false;
         }

--- a/src/util.h
+++ b/src/util.h
@@ -296,12 +296,12 @@ public:
     /**
      * Get the help string
      */
-    std::string GetHelpMessage();
+    std::string GetHelpMessage() const;
 
     /**
      * Check whether we know of this arg
      */
-    bool IsArgKnown(const std::string& key, std::string& error);
+    bool IsArgKnown(const std::string& key) const;
 };
 
 extern ArgsManager gArgs;


### PR DESCRIPTION
This commit contains 2 refactors.

1. mark "const" on ArgsManager::GetHelpMessage and IsArgKnown.
2. remove unused "error" argument from ArgsManager::IsArgKnown.

Firstly, I mark "const" on where it is possible to. It is mentioned
before (e.g. https://github.com/bitcoin/bitcoin/pull/13190#pullrequestreview-118823133).

And about 2nd change, ArgsManager::IsArgKnown was added at commit #4f8704d which was
merged at PR #13112. But from its beggining, "error" argument never be used.
I think it should be refactored.