### PR TITLE
Net: Fixed a race condition when disabling the network.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1169,6 +1169,17 @@ void CConnman::ThreadSocketHandler()
         //
         {
             LOCK(cs_vNodes);
+
+            if (!fNetworkActive) {
+                // Disconnect any connected nodes
+                for (CNode* pnode : vNodes) {
+                    if (!pnode->fDisconnect) {
+                        LogPrint(BCLog::NET, "Network not active, dropping peer=%d\n", pnode->GetId());
+                        pnode->fDisconnect = true;
+                    }
+                }
+            }
+
             // Disconnect unused nodes
             std::vector<CNode*> vNodesCopy = vNodes;
             for (CNode* pnode : vNodesCopy)
@@ -2243,14 +2254,6 @@ void CConnman::SetNetworkActive(bool active)
     }
 
     fNetworkActive = active;
-
-    if (!fNetworkActive) {
-        LOCK(cs_vNodes);
-        // Close sockets to all nodes
-        for (CNode* pnode : vNodes) {
-            pnode->CloseSocketDisconnect();
-        }
-    }
 
     uiInterface.NotifyNetworkActiveChanged(fNetworkActive);
 }


### PR DESCRIPTION
This change addresses a race condition where setnetworkactive=false wouldn't always disconnect all peers.

Before this change, the following could happen:
1. Thread A -- Begins connecting to a node.
2. Thread B -- Sets kNetworkActive=false and disconnects connected nodes.
3. Thread A -- Finishes connecting and adds node to list of connected nodes.

The node that was connected from Thread A remains connected and active,
even though kNetworkActive=false.

To fix the race, disconnections when kNetworkActive=false are now handled in the main network loop.

fixes #13038