### PR TITLE
release: require macOS 10.10+

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -94,6 +94,6 @@ Other commands:
 Notes
 -----
 
-* Tested on OS X 10.11 through 10.13 on 64-bit Intel processors only.
+* Tested on OS X 10.10 Yosemite through macOS 10.13 High Sierra on 64-bit Intel processors only.
 
 * Building with downloaded Qt binaries is not officially supported. See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714)

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -37,10 +37,13 @@ Compatibility
 ==============
 
 Chaincoin Core is extensively tested on multiple operating systems using
-the Linux kernel, macOS 10.11+, and Windows 7 and newer (Windows XP is not supported).
+the Linux kernel, macOS 10.10+, and Windows 7 and newer (Windows XP is not supported).
 
 Chaincoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
+
+From 0.17.0 onwards macOS <10.10 is no longer supported. 0.17.0 is built using Qt 5.9.x, which doesn't
+support versions of macOS older than 10.10.
 
 Notable changes
 ===============

--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -3,7 +3,7 @@
 <plist version="0.9">
 <dict>
   <key>LSMinimumSystemVersion</key>
-  <string>10.8.0</string>
+  <string>10.10.0</string>
 
   <key>LSArchitecturePriority</key>
   <array>

--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -15,7 +15,7 @@
 #include <byteswap.h>
 #endif
 
-#if defined(__APPLE__)
+#if defined(MAC_OSX)
 
 #if !defined(bswap_16)
 
@@ -61,6 +61,6 @@ inline uint64_t bswap_64(uint64_t x)
 }
 #endif // HAVE_DECL_BSWAP64 == 0
 
-#endif // defined(__APPLE__)
+#endif // defined(MAC_OSX)
 
 #endif // BITCOIN_COMPAT_BYTESWAP_H

--- a/src/qt/chaincoin.cpp
+++ b/src/qt/chaincoin.cpp
@@ -616,7 +616,6 @@ int main(int argc, char *argv[])
     QApplication::setOrganizationName(QAPP_ORG_NAME);
     QApplication::setOrganizationDomain(QAPP_ORG_DOMAIN);
     QApplication::setApplicationName(QAPP_APP_NAME_DEFAULT);
-    GUIUtil::SubstituteFonts(GetLangTerritory());
 
     /// 4. Initialization of translations, so that intro dialog is in user's language
     // Now that QSettings are accessible, initialize translations

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -64,16 +64,6 @@
 
 static fs::detail::utf8_codecvt_facet utf8;
 
-#if defined(Q_OS_MAC)
-extern double NSAppKitVersionNumber;
-#if !defined(NSAppKitVersionNumber10_8)
-#define NSAppKitVersionNumber10_8 1187
-#endif
-#if !defined(NSAppKitVersionNumber10_9)
-#define NSAppKitVersionNumber10_9 1265
-#endif
-#endif
-
 namespace GUIUtil {
 
 QString dateTimeStr(const QDateTime &date)
@@ -416,42 +406,6 @@ void showBackups()
     /* Open folder with default browser */
     if (fs::exists(backupsDir))
         QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(backupsDir)));
-}
-
-void SubstituteFonts(const QString& language)
-{
-#if defined(Q_OS_MAC)
-// Background:
-// OSX's default font changed in 10.9 and Qt is unable to find it with its
-// usual fallback methods when building against the 10.7 sdk or lower.
-// The 10.8 SDK added a function to let it find the correct fallback font.
-// If this fallback is not properly loaded, some characters may fail to
-// render correctly.
-//
-// The same thing happened with 10.10. .Helvetica Neue DeskInterface is now default.
-//
-// Solution: If building with the 10.7 SDK or lower and the user's platform
-// is 10.9 or higher at runtime, substitute the correct font. This needs to
-// happen before the QApplication is created.
-#if defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_8
-    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_8)
-    {
-        if (floor(NSAppKitVersionNumber) <= NSAppKitVersionNumber10_9)
-            /* On a 10.9 - 10.9.x system */
-            QFont::insertSubstitution(".Lucida Grande UI", "Lucida Grande");
-        else
-        {
-            /* 10.10 or later system */
-            if (language == "zh_CN" || language == "zh_TW" || language == "zh_HK") // traditional or simplified Chinese
-              QFont::insertSubstitution(".Helvetica Neue DeskInterface", "Heiti SC");
-            else if (language == "ja") // Japanese
-              QFont::insertSubstitution(".Helvetica Neue DeskInterface", "Songti SC");
-            else
-              QFont::insertSubstitution(".Helvetica Neue DeskInterface", "Lucida Grande");
-        }
-    }
-#endif
-#endif
 }
 
 ToolTipToRichTextFilter::ToolTipToRichTextFilter(int _size_threshold, QObject *parent) :

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -127,9 +127,6 @@ namespace GUIUtil
     // Browse backup folder
     void showBackups();
 
-    // Replace invalid default fonts with known good ones
-    void SubstituteFonts(const QString& language);
-
     /** Qt event filter that intercepts ToolTipChange events, and replaces the tooltip with a rich text
       representation if needed. This assures that Qt can word-wrap long tooltip messages.
       Tooltips longer than the provided size threshold (in characters) are wrapped.

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -148,19 +148,7 @@ namespace tfm = tinyformat;
 #   endif
 #endif
 
-#if defined(__GLIBCXX__) && __GLIBCXX__ < 20080201
-//  std::showpos is broken on old libstdc++ as provided with OSX.  See
-//  http://gcc.gnu.org/ml/libstdc++/2007-11/msg00075.html
-#   define TINYFORMAT_OLD_LIBSTDCPLUSPLUS_WORKAROUND
-#endif
-
-#ifdef __APPLE__
-// Workaround OSX linker warning: Xcode uses different default symbol
-// visibilities for static libs vs executables (see issue #25)
-#   define TINYFORMAT_HIDDEN __attribute__((visibility("hidden")))
-#else
-#   define TINYFORMAT_HIDDEN
-#endif
+#define TINYFORMAT_HIDDEN
 
 namespace tinyformat {
 
@@ -228,27 +216,6 @@ struct formatValueAsType<T,fmtT,true>
     static void invoke(std::ostream& out, const T& value)
         { out << static_cast<fmtT>(value); }
 };
-
-#ifdef TINYFORMAT_OLD_LIBSTDCPLUSPLUS_WORKAROUND
-template<typename T, bool convertible = is_convertible<T, int>::value>
-struct formatZeroIntegerWorkaround
-{
-    static bool invoke(std::ostream& /**/, const T& /**/) { return false; }
-};
-template<typename T>
-struct formatZeroIntegerWorkaround<T,true>
-{
-    static bool invoke(std::ostream& out, const T& value)
-    {
-        if (static_cast<int>(value) == 0 && out.flags() & std::ios::showpos)
-        {
-            out << "+0";
-            return true;
-        }
-        return false;
-    }
-};
-#endif // TINYFORMAT_OLD_LIBSTDCPLUSPLUS_WORKAROUND
 
 // Convert an arbitrary type to integer.  The version with convertible=false
 // throws an error.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1047,7 +1047,7 @@ bool FileCommit(FILE *file)
         LogPrintf("%s: fdatasync failed: %d\n", __func__, errno);
         return false;
     }
-    #elif defined(__APPLE__) && defined(F_FULLFSYNC)
+    #elif defined(MAC_OSX) && defined(F_FULLFSYNC)
     if (fcntl(fileno(file), F_FULLFSYNC, 0) == -1) { // Manpage says "value other than -1" is returned on success
         LogPrintf("%s: fcntl F_FULLFSYNC failed: %d\n", __func__, errno);
         return false;


### PR DESCRIPTION
Closes #13362

d99abfddb0c8f2111340a6127e77cc686e0043d8
This workaround should no longer be required, as it should have only been in use when compiled with the 10.7 SDK, which we haven't been building with for a while now.

5bc5ae30982a0f0f6a9804b05d99434af770c724
The bugreport linked with this code is for an unrelated? issue, however from what I can tell the correct QTBUG is this one https://bugreports.qt.io/browse/QTBUG-20880. Reading though the discussion there, it seems that the way progress bars are animated changed in macOS 10.10.
Qt was patched [here (5.5+)](https://codereview.qt-project.org/#/c/112379/):
> Disable progress bar animations on 10.10 Yosemite and higher - the native style does not animate them any more. Keep the indeterminate progress bar animation.

Given all of that, I don't think this is worth keeping around, as it would seem to only be useful in the case that a macOS user is compiling with a Qt < 5.5. That should be pretty unlikely, as we don't support downloaded Qt binaries, and brew currently provides [5.11.1](https://github.com/Homebrew/homebrew-core/blob/571b46213c70ca1573da6d0425b0bd6df34961ee/Formula/qt.rb).