### PR TITLE
doc: Minor improvements to release-process.md

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -37,7 +37,7 @@ Scripts and notes for Mac builds.
 ### [RPM](/contrib/rpm) ###
 RPM spec file for building bitcoin-core on RPM based distributions.
 
-### [Gitian-build](/contrib/gitian-build.sh) ###
+### [Gitian-build](/contrib/gitian-build.py) ###
 Script for running full Gitian builds.
 
 Test and Verify Tools 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -50,7 +50,7 @@ and sort them into categories based on labels)
 
 Generate list of authors:
 
-    git log --format='%aN' "$*" | sort -ui | sed -e 's/^/- /'
+    git log --format='- %aN' v(current version, e.g. 0.16.0)..v(new version, e.g. 0.16.1) | sort -fiu
 
 Tag version (or release candidate) in git
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -29,7 +29,7 @@ Before every major release:
 
 ### First time / New builders
 
-If you're using the automated script (found in [contrib/gitian-build.sh](/contrib/gitian-build.sh)), then at this point you should run it with the "--setup" command. Otherwise ignore this.
+If you're using the automated script (found in [contrib/gitian-build.py](/contrib/gitian-build.py)), then at this point you should run it with the "--setup" command. Otherwise ignore this.
 
 Check out the source code in the following directory hierarchy.
 
@@ -58,7 +58,7 @@ Tag version (or release candidate) in git
 
 ### Setup and perform Gitian builds
 
-If you're using the automated script (found in [contrib/gitian-build.sh](/contrib/gitian-build.sh)), then at this point you should run it with the "--build" command. Otherwise ignore this.
+If you're using the automated script (found in [contrib/gitian-build.py](/contrib/gitian-build.py)), then at this point you should run it with the "--build" command. Otherwise ignore this.
 
 Setup Gitian descriptors:
 


### PR DESCRIPTION
- Update broken links
- Improve command to generate list of authors for a release

---

I also note that it asks to ping **wumpus** on IRC, to assist in generating a list of merged pulls and sort them into categories based on labels. I tried to turn this into a simple one-liner as well (something like ``git log --merges --format="- \`%h\` %s (%an)" v0.16.0..v0.16.1``), but it didn't seem to capture everything I needed.

Would it be worthwhile **wumpus** open-sourcing his code into `contrib/devtools` so there is no single point of failure (even if it can manually be worked around).