### PR TITLE
Acquire cs_main before ATMP call in block_assemble bench

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -97,10 +97,14 @@ static void AssembleBlock(benchmark::State& state)
         if (NUM_BLOCKS - b >= COINBASE_MATURITY)
             txs.at(b) = MakeTransactionRef(tx);
     }
-    for (const auto& txr : txs) {
-        CValidationState state;
-        bool ret{::AcceptToMemoryPool(::mempool, state, txr, nullptr /* pfMissingInputs */, nullptr /* plTxnReplaced */, false /* bypass_limits */, /* nAbsurdFee */ 0)};
-        assert(ret);
+    {
+        LOCK(::cs_main); // Required for ::AcceptToMemoryPool.
+
+        for (const auto& txr : txs) {
+            CValidationState state;
+            bool ret{::AcceptToMemoryPool(::mempool, state, txr, nullptr /* pfMissingInputs */, nullptr /* plTxnReplaced */, false /* bypass_limits */, /* nAbsurdFee */ 0)};
+            assert(ret);
+        }
     }
 
     while (state.KeepRunning()) {


### PR DESCRIPTION
Otherwise we fail an assert in sync.cpp:AssertLockHeldInternal.