### PR TITLE
 Ignore unknown config file options; warn instead of error

### DIFF
--- a/src/chaincoind.cpp
+++ b/src/chaincoind.cpp
@@ -96,7 +96,7 @@ static bool AppInit(int argc, char* argv[])
             fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", gArgs.GetArg("-datadir", "").c_str());
             return false;
         }
-        if (!gArgs.ReadConfigFiles(error)) {
+        if (!gArgs.ReadConfigFiles(error, true)) {
             fprintf(stderr, "Error reading configuration file: %s\n", error.c_str());
             return false;
         }

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -57,7 +57,7 @@ class NodeImpl : public Node
     {
         return gArgs.ParseParameters(argc, argv, error);
     }
-    bool readConfigFiles(std::string& error) override { return gArgs.ReadConfigFiles(error); }
+    bool readConfigFiles(std::string& error) override { return gArgs.ReadConfigFiles(error, true); }
     bool softSetArg(const std::string& arg, const std::string& value) override { return gArgs.SoftSetArg(arg, value); }
     bool softSetBoolArg(const std::string& arg, bool value) override { return gArgs.SoftSetBoolArg(arg, value); }
     void selectParams(const std::string& network) override { SelectParams(network); }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -885,9 +885,13 @@ bool ArgsManager::ReadConfigStream(std::istream& stream, std::string& error, boo
         }
 
         // Check that the arg is known
-        if (!IsArgKnown(strKey) && !ignore_invalid_keys) {
-            error = strprintf("Invalid configuration value %s", option.first.c_str());
-            return false;
+        if (!IsArgKnown(strKey)) {
+            if (!ignore_invalid_keys) {
+                error = strprintf("Invalid configuration value %s", option.first.c_str());
+                return false;
+            } else {
+                LogPrintf("Ignoring unknown configuration value %s\n", option.first);
+            }
         }
     }
     return true;

--- a/test/functional/feature_includeconf.py
+++ b/test/functional/feature_includeconf.py
@@ -55,9 +55,11 @@ class IncludeConfTest(BitcoinTestFramework):
         self.stop_node(0, expected_stderr="warning: -includeconf cannot be used from included files; ignoring -includeconf=relative2.conf")
 
         self.log.info("-includeconf cannot contain invalid arg")
-        with open(os.path.join(self.options.tmpdir, "node0", "relative.conf"), "w", encoding="utf8") as f:
-            f.write("foo=bar\n")
-        self.nodes[0].assert_start_raises_init_error(expected_msg="Error reading configuration file: Invalid configuration value foo")
+
+        # Commented out as long as we ignore invalid arguments in configuration files
+        #with open(os.path.join(self.options.tmpdir, "node0", "relative.conf"), "w", encoding="utf8") as f:
+        #    f.write("foo=bar\n")
+        #self.nodes[0].assert_start_raises_init_error(expected_msg="Error reading configuration file: Invalid configuration value foo")
 
         self.log.info("-includeconf cannot be invalid path")
         os.remove(os.path.join(self.options.tmpdir, "node0", "relative.conf"))


### PR DESCRIPTION
As reported by @satwo on IRC a few days ago, the current mechanism of treating unknown config file options as errors is problematic for options like `-rpcclienttimeout` which aren't defined for `bitcoind`.

A full solution would be to either make all binaries be aware of each other's options, or to permit config file options that only apply to specific binaries (`bitcoind`, `bitcoin-qt`, `bitcoin-cli`). Both of these seem too invasive to introduce for 0.17.

As a compromise, this PR makes it ignores those options, but still warn about it in the log file.