### PR TITLE
wallet: Fix backupwallet for multiwallets

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -768,7 +768,7 @@ bool BerkeleyDatabase::Backup(const std::string& strDest)
                 env->mapFileUseCount.erase(strFile);
 
                 // Copy wallet file
-                fs::path pathSrc = GetWalletDir() / strFile;
+                fs::path pathSrc = env->Directory() / strFile;
                 fs::path pathDest(strDest);
                 if (fs::is_directory(pathDest))
                     pathDest /= strFile;


### PR DESCRIPTION
backupwallet was broken for multiwallets in their own directories
(i.e. something like DATADIR/wallets/mywallet/wallet.dat).  In this
case, the backup would use DATADIR/wallets/wallet.dat as source file
and not take the specific wallet's directory into account.

This led to either an error during the backup (if the wrong source
file was not present) or would silently back up the wrong wallet;
especially the latter behaviour can be quite bad for users.