### PR TITLE
Docs: fix GetWarnings docs to reflect behavior

### DIFF
--- a/src/warnings.h
+++ b/src/warnings.h
@@ -14,10 +14,10 @@ void SetfLargeWorkForkFound(bool flag);
 bool GetfLargeWorkForkFound();
 void SetfLargeWorkInvalidChainFound(bool flag);
 /** Format a string that describes several potential problems detected by the core.
- * strFor can have three values:
- * - "statusbar": get all warnings
- * - "gui": get all warnings, translated (where possible) for GUI
- * This function only returns the highest priority warning of the set selected by strFor.
+ * @param[in] strFor can have the following values:
+ * - "statusbar": get the most important warning
+ * - "gui": get all warnings, translated (where possible) for GUI, separated by <hr />
+ * @returns the warning string selected by strFor
  */
 std::string GetWarnings(const std::string& strFor);
 


### PR DESCRIPTION
In "gui", it returns all warnings, joined by a separator
In "statusbar", it returns just the first warning