### PR TITLE
Introduce a maximum size for locators.

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -45,6 +45,8 @@ static const int TIMEOUT_INTERVAL = 20 * 60;
 static const int FEELER_INTERVAL = 120;
 /** The maximum number of entries in an 'inv' protocol message */
 static const unsigned int MAX_INV_SZ = 50000;
+/** The maximum number of entries in a locator */
+static const unsigned int MAX_LOCATOR_SZ = 101;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
 /** Maximum length of incoming protocol messages (no message over 4 MB is currently acceptable). */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2141,6 +2141,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         uint256 hashStop;
         vRecv >> locator >> hashStop;
 
+        if (locator.vHave.size() > MAX_LOCATOR_SZ) {
+            LogPrint(BCLog::NET, "getblocks locator size %lld > %d, disconnect peer=%d\n", locator.vHave.size(), MAX_LOCATOR_SZ, pfrom->GetId());
+            pfrom->fDisconnect = true;
+            return true;
+        }
+
         // We might have announced the currently-being-connected tip using a
         // compact block, which resulted in the peer sending a getblocks
         // request, which we would otherwise respond to without the new block.
@@ -2252,6 +2258,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         CBlockLocator locator;
         uint256 hashStop;
         vRecv >> locator >> hashStop;
+
+        if (locator.vHave.size() > MAX_LOCATOR_SZ) {
+            LogPrint(BCLog::NET, "getheaders locator size %lld > %d, disconnect peer=%d\n", locator.vHave.size(), MAX_LOCATOR_SZ, pfrom->GetId());
+            pfrom->fDisconnect = true;
+            return true;
+        }
 
         LOCK(cs_main);
         if (IsInitialBlockDownload() && !pfrom->fWhitelisted) {


### PR DESCRIPTION
The largest sensible size for a locator is log in the number of blocks.
 But, as noted by Coinr8d on BCT a maximum size message could encode a
 hundred thousand locators.  If height were used to limit the messages
 that could open new attacks where peers on long low diff forks would
 get disconnected and end up stuck.

Ideally, nodes first first learn to limit the size of locators they
 send before limiting what would be processed, but common implementations
 back off with an exponent of 2 and have an implicit limit of 2^32
 blocks, so they already cannot produce locators over some size.

This sets the limit to an absurdly high amount of 101 in order to
 maximize compatibility with existing software.