### PR TITLE
Use pushKV in some new PSBT RPCs.

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1664,12 +1664,12 @@ UniValue finalizepsct(const JSONRPCRequest& request)
             mtx.vin[i].scriptWitness = psctx.inputs[i].final_script_witness;
         }
         ssTx << mtx;
-        result.push_back(Pair("hex", HexStr(ssTx.begin(), ssTx.end())));
+        result.pushKV("hex", HexStr(ssTx.begin(), ssTx.end()));
     } else {
         ssTx << psctx;
-        result.push_back(Pair("psct", EncodeBase64((unsigned char*)ssTx.data(), ssTx.size())));
+        result.pushKV("psct", EncodeBase64((unsigned char*)ssTx.data(), ssTx.size()));
     }
-    result.push_back(Pair("complete", complete));
+    result.pushKV("complete", complete);
 
     return result;
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4653,8 +4653,8 @@ UniValue walletprocesspsct(const JSONRPCRequest& request)
     UniValue result(UniValue::VOBJ);
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << psctx;
-    result.push_back(Pair("psct", EncodeBase64((unsigned char*)ssTx.data(), ssTx.size())));
-    result.push_back(Pair("complete", complete));
+    result.pushKV("psct", EncodeBase64((unsigned char*)ssTx.data(), ssTx.size()));
+    result.pushKV("complete", complete);
 
     return result;
 }


### PR DESCRIPTION
Most of the code uses UniValue::pushKV where appropriate, but some new
RPC code related to PSBTs did not.