### PR TITLE
docs: fixed bitcoin-cli -help output for help2man

### DIFF
--- a/src/chaincoin-cli.cpp
+++ b/src/chaincoin-cli.cpp
@@ -50,8 +50,8 @@ static void SetupCliArgs()
     gArgs.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcwait", "Wait for RPC server to start", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcwallet=<walletname>", "Send RPC for non-default wallet on RPC server (needs to exactly match corresponding -wallet option passed to bitcoind)", false, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-stdin", "Read extra arguments from standard input, one per line until EOF/Ctrl-D (recommended for sensitive information such as passphrases).  When combined with -stdinrpcpass, the first line from standard input is used for the RPC password.", false, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-stdinrpcpass", strprintf("Read RPC password from standard input as a single line.  When combined with -stdin, the first line from standard input is used for the RPC password."), false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-stdin", "Read extra arguments from standard input, one per line until EOF/Ctrl-D (recommended for sensitive information such as passphrases). When combined with -stdinrpcpass, the first line from standard input is used for the RPC password.", false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-stdinrpcpass", "Read RPC password from standard input as a single line. When combined with -stdin, the first line from standard input is used for the RPC password.", false, OptionsCategory::OPTIONS);
 
     // Hidden
     gArgs.AddArg("-h", "", false, OptionsCategory::HIDDEN);


### PR DESCRIPTION
The `help2man` parses a string containing two spaces between words with an issue:
it gives out `.TP` and `.IP` commands instead of a single `.IP` command.
Removing an extra space fixes this issue.
Currently the `-help` output for the `-stdin` option looks without any issue due to eliminating
of two spaces between words by a `FormatParagraph` call for this particular case.
For consistency and preventing from future regressions extra spaces have been removed from the both lines.
The redundant `strprintf` call has been removed aswell.