### PR TITLE
Allow ConstructTransaction to not throw error with 0-input txn

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -439,7 +439,7 @@ CMutableTransaction ConstructTransaction(const UniValue& inputs_in, const UniVal
         }
     }
 
-    if (!rbf.isNull() && rbfOptIn != SignalsOptInRBF(rawTx)) {
+    if (!rbf.isNull() && rawTx.vin.size() > 0 && rbfOptIn != SignalsOptInRBF(rawTx)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter combination: Sequence number(s) contradict replaceable option");
     }
 


### PR DESCRIPTION
Github-Pull: #13968
Rebased-From: 2252ec50085c151e7998ca9a30cda6a33ee862b6
Tree-SHA512: 1f9978ee25fbe9bb338af19d81b401fa531d314ac8288cdb21c1bf10459edea50b43e2d5e97c9bb5fe24c8db89363f8233c0a3d96066ed85f7bd6d2eb234aac0