### PR TITLE
RPCTypeCheck bip32derivs arg in walletcreatefunded

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4737,7 +4737,8 @@ UniValue walletcreatefundedpsct(const JSONRPCRequest& request)
         UniValue::VARR,
         UniValueType(), // ARR or OBJ, checked later
         UniValue::VNUM,
-        UniValue::VOBJ
+        UniValue::VOBJ,
+        UniValue::VBOOL
         }, true
     );
 


### PR DESCRIPTION
Github-Pull: #13968
Rebased-From: faaac5caaab4d5131040292f4ef2404074ad268b
Tree-SHA512: 758c0c3e4435897d1a9b03ea93f1b2a1a1b64071eda9450f968acf537c172ee61acf9d962bc22ddb6de26e0ad39d9165cdee6f260bb5a95bf97b4003853f0874