### PR TITLE
Bugfix: NSIS: Exclude Makefile* from docs

### DIFF
--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -81,7 +81,7 @@ Section -Main SEC0000
     File @abs_top_srcdir@/release/@BITCOIN_DAEMON_NAME@@EXEEXT@
     File @abs_top_srcdir@/release/@BITCOIN_CLI_NAME@@EXEEXT@
     SetOutPath $INSTDIR\doc
-    File /r @abs_top_srcdir@/doc\*.*
+    File /r /x Makefile* @abs_top_srcdir@/doc\*.*
     SetOutPath $INSTDIR
     WriteRegStr HKCU "${REGKEY}\Components" Main 1
 SectionEnd


### PR DESCRIPTION
Otherwise, the generated Makefile is included in the NSIS-installed documentation, which can lead to non-determinism (eg, if gawk is installed on some build VMs, but others only have mawk)

Github-Pull: #14018
Rebased-From: 8563341714a1ec452dd3304a39dd880face49c84
Tree-SHA512: 2d219a4a2027bcd7359b7320bafc6b7cd3bde3dcf9309ddd6198ff67407470025baa71e6d0ed3d6cec081834ddc9a0247043865eb26737e6fd0d2f09574f5932