### PR TITLE
module initial sync: adjust to needs

### DIFF
--- a/src/modules/masternode/masternode.cpp
+++ b/src/modules/masternode/masternode.cpp
@@ -743,7 +743,7 @@ bool CMasternodePing::SimpleCheck(int& nDos)
 
     {
         AssertLockHeld(cs_main);
-        BlockMap::iterator mi = mapBlockIndex.find(blockHash);
+        auto mi = mapBlockIndex.find(blockHash);
         if (mi == mapBlockIndex.end()) {
             LogPrint(BCLog::MNODE, "CMasternodePing::SimpleCheck -- Masternode ping is invalid, unknown block hash: masternode=%s blockHash=%s\n", masternodeOutpoint.ToStringShort(), blockHash.ToString());
             // maybe we stuck or forked so we shouldn't ban this node, just fail to accept this ping
@@ -785,8 +785,8 @@ bool CMasternodePing::CheckAndUpdate(CMasternode* pmn, bool fFromNewBroadcast, i
     }
 
     {
-        BlockMap::iterator mi = mapBlockIndex.find(blockHash);
-        if ((*mi).second && (*mi).second->nHeight < chainActive.Height() - 24) {
+        auto mi = mapBlockIndex.find(blockHash);
+        if ((*mi).second && (*mi).second->nHeight < chainActive.Height() - MASTERNODE_MAX_MNP_BLOCKS) {
             LogPrintf("CMasternodePing::CheckAndUpdate -- Masternode ping is invalid, block hash is too old: masternode=%s  blockHash=%s\n", masternodeOutpoint.ToStringShort(), blockHash.ToString());
             // nDos = 1;
             return false;

--- a/src/modules/masternode/masternode.h
+++ b/src/modules/masternode/masternode.h
@@ -24,8 +24,9 @@ static const int MASTERNODE_SENTINEL_PING_MAX_SECONDS   =  60 * 60;
 static const int MASTERNODE_EXPIRATION_SECONDS          = 120 * 60;
 static const int MASTERNODE_NEW_START_REQUIRED_SECONDS  = 180 * 60;
 
-static const int MASTERNODE_POSE_BAN_MAX_SCORE          = 5;
-static const int MASTERNODE_MAX_MIXING_TXES             = 5;
+static const int MASTERNODE_MAX_MNP_BLOCKS              = 60;
+static const int MASTERNODE_POSE_BAN_MAX_SCORE          =  5;
+static const int MASTERNODE_MAX_MIXING_TXES             =  5;
 
 //
 // The Masternode Ping Class : Contains a different serialize method for sending pings from masternodes throughout the network

--- a/src/net.h
+++ b/src/net.h
@@ -883,19 +883,17 @@ public:
     void PushInventory(const CInv& inv)
     {
         LOCK(cs_inventory);
-        if (inv.type == MSG_TX) {
-            if (!filterInventoryKnown.contains(inv.hash)) {
-                LogPrint(BCLog::NET, "PushInventory --  inv: %s peer=%d\n", inv.ToString(), id);
-                setInventoryTxToSend.insert(inv.hash);
-            } else {
-                LogPrint(BCLog::NET, "PushInventory --  filtered inv: %s peer=%d\n", inv.ToString(), id);
-            }
+        if (inv.type == MSG_TX && !filterInventoryKnown.contains(inv.hash)) {
+            LogPrint(BCLog::NET, "PushInventory --  inv: %s peer=%d\n", inv.ToString(), id);
+            setInventoryTxToSend.insert(inv.hash);
         } else if (inv.type == MSG_BLOCK) {
             LogPrint(BCLog::NET, "PushInventory --  inv: %s peer=%d\n", inv.ToString(), id);
             vInventoryBlockToSend.push_back(inv.hash);
-        } else {
+        } else if (!filterInventoryKnown.contains(inv.hash)) {
             LogPrint(BCLog::NET, "PushInventory --  inv: %s peer=%d\n", inv.ToString(), id);
             vInventoryOtherToSend.push_back(inv);
+        } else {
+            LogPrint(BCLog::NET, "PushInventory --  filtered inv: %s peer=%d\n", inv.ToString(), id);
         }
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -70,7 +70,7 @@ static constexpr int STALE_RELAY_AGE_LIMIT = 30 * 24 * 60 * 60;
 /// limiting block relay. Set to one week, denominated in seconds.
 static constexpr int HISTORICAL_BLOCK_AGE = 7 * 24 * 60 * 60;
 /** Maximum number of in-flight inventory items from a peer */
-static constexpr int32_t MAX_PEER_INV_IN_FLIGHT = 100;
+static constexpr int32_t MAX_PEER_INV_IN_FLIGHT = 3000;
 /** Maximum number of announced inventory items from a peer */
 static constexpr int32_t MAX_PEER_INV_ANNOUNCEMENTS = 2 * MAX_INV_SZ;
 /** How many microseconds to delay requesting inventory items from inbound peers */
@@ -3279,7 +3279,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         {
             //probably for one of the modules
             GetMainSignals().ProcessModuleMessage(pfrom, strCommand, vRecv, connman);
-            LogPrint(BCLog::NET, "Forwarded message \"%s\" from peer=%d\n", SanitizeString(strCommand), pfrom->GetId());
+            LogPrint(BCLog::NET, "Forwarded message \"%s\" from peer=%d to Chaincoin modules\n", SanitizeString(strCommand), pfrom->GetId());
         } else {
             // Ignore unknown commands for extensibility
             LogPrint(BCLog::NET, "Unknown command \"%s\" from peer=%d\n", SanitizeString(strCommand), pfrom->GetId());


### PR DESCRIPTION
- allow MNP age being slightly more than the MNP_TIMEOUT (in blocks)
- (temporarily) allow up to 3000 inventory items to be synced per peer