### PR TITLE
 [CoinJoin!] introduce AnalyzeCoin to determine the obscuring level

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -185,6 +185,10 @@ public:
             fn(entry.GetSharedTx());
         }
     }
+    int analyzeCoin(const COutPoint& outpoint) override
+    {
+        return AnalyzeCoin(outpoint);
+    }
 };
 
 } // namespace

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -144,6 +144,9 @@ public:
     //! to be prepared to handle this by ignoring notifications about unknown
     //! removed transactions and already added new transactions.
     virtual void requestMempoolTransactions(std::function<void(const CTransactionRef&)> fn) = 0;
+
+    //! Recursively calculate the depth of obscuring a single outpoint.
+    virtual int analyzeCoin(const COutPoint& outpoint) = 0;
 };
 
 //! Interface to let node manage chain clients (wallets, or maybe tools for

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -442,6 +442,10 @@ public:
     {
         return g_connman ? ::governance.VoteWithAll(hash, strVoteSignal, nResult, g_connman.get()) : false;
     }
+    int analyzeCoin(const COutPoint& outpoint) override
+    {
+        return AnalyzeCoin(outpoint);
+    }
     std::string getWalletDir() override
     {
         return GetWalletDir().string();

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -190,6 +190,9 @@ public:
     //! Get unspent outputs associated with a transaction.
     virtual bool getUnspentOutput(const COutPoint& output, Coin& coin) = 0;
 
+    //! Recursively calculate the depth of obscuring a single outpoint.
+    virtual int analyzeCoin(const COutPoint& outpoint) = 0;
+
     //! Module signals
     virtual std::string getModuleSyncStatus() = 0;
     virtual bool isMasternodeChainSynced() = 0;

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -458,7 +458,7 @@ public:
     }
     int getCappedOutpointCoinJoinRounds(const COutPoint& outpoint) override
     {
-        return m_wallet->GetCappedOutpointCoinJoinRounds(outpoint);
+        return m_wallet->chain().analyzeCoin(outpoint);
     }
     CAmount getRequiredFee(unsigned int tx_bytes) override { return GetRequiredFee(*m_wallet, tx_bytes); }
     CAmount getMinimumFee(unsigned int tx_bytes,
@@ -480,11 +480,11 @@ public:
     OutputType getDefaultAddressType() override { return m_wallet->m_default_address_type; }
     OutputType getDefaultChangeType() override { return m_wallet->m_default_change_type; }
 
-    int getPSRounds() override { return m_wallet->coinjoinClient->nCoinJoinRounds; }
+    int getCJDepth() override { return m_wallet->coinjoinClient->nCoinJoinDepth; }
 
     void setCoinJoinParams(const int& rounds, const int& amount) override
     {
-        m_wallet->coinjoinClient->nCoinJoinRounds = rounds;
+        m_wallet->coinjoinClient->nCoinJoinDepth = rounds;
         m_wallet->coinjoinClient->nCoinJoinAmount = amount;
         m_wallet->coinjoinClient->nCachedNumBlocks = std::numeric_limits<int>::max();
     }
@@ -494,7 +494,7 @@ public:
         CoinJoinConstants result;
         result.minamount = COINJOIN_LOW_DENOM;
         result.defaultamount = DEFAULT_COINJOIN_AMOUNT;
-        result.defaultrounds = DEFAULT_COINJOIN_ROUNDS;
+        result.defaultrounds = DEFAULT_COINJOIN_DEPTH;
         result.keyswarning = COINJOIN_KEYS_THRESHOLD_WARNING;
         return result;
     }
@@ -505,7 +505,7 @@ public:
         result.enabled = m_wallet->coinjoinClient->fEnableCoinJoin;
         result.cachednumblocks = m_wallet->coinjoinClient->nCachedNumBlocks;
         result.amount = m_wallet->coinjoinClient->nCoinJoinAmount;
-        result.rounds = m_wallet->coinjoinClient->nCoinJoinRounds;
+        result.depth = m_wallet->coinjoinClient->nCoinJoinDepth;
         result.denom = m_wallet->coinjoinClient->GetSessionDenoms();
         result.status = m_wallet->coinjoinClient->GetStatuses();
         result.keysleft = m_wallet->nKeysLeftSinceAutoBackup;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -254,7 +254,7 @@ public:
     virtual OutputType getDefaultChangeType() = 0;
 
     //! Return CoinJoin Rounds.
-    virtual int getPSRounds() = 0;
+    virtual int getCJDepth() = 0;
 
     //! Change CoinJoin Params.
     virtual void setCoinJoinParams(const int& rounds, const int& amount) = 0;
@@ -379,7 +379,7 @@ struct CoinJoinStatus
     bool enabled = 0;
     int cachednumblocks = 0;
     int amount = 0;
-    int rounds = 0;
+    int depth = 0;
     bool multisession = false;
     std::string denom = "";
     int64_t keysleft = 0;
@@ -387,7 +387,7 @@ struct CoinJoinStatus
 
     bool coinJoinChanged(const CoinJoinStatus& prev) const
     {
-        return enabled != prev.enabled || cachednumblocks != prev.cachednumblocks || amount != prev.amount || rounds != prev.rounds
+        return enabled != prev.enabled || cachednumblocks != prev.cachednumblocks || amount != prev.amount || depth != prev.depth
                || multisession != prev.multisession || status != prev.status || denom != prev.denom || keysleft != prev.keysleft;
     }
 };

--- a/src/modules/coinjoin/coinjoin.cpp
+++ b/src/modules/coinjoin/coinjoin.cpp
@@ -295,7 +295,7 @@ bool CCoinJoin::IsInDenomRange(const CAmount& nAmount)
 
 bool CCoinJoin::IsDenominatedAmount(CAmount nInputAmount)
 {
-    for (auto denom = COINJOIN_HIGH_DENOM; denom >= COINJOIN_LOW_DENOM; denom >>=1) {
+    for (auto denom = COINJOIN_LOW_DENOM; denom <= COINJOIN_HIGH_DENOM; denom <<=1) {
         if(nInputAmount == denom) {
             return true;
         }

--- a/src/modules/coinjoin/coinjoin.h
+++ b/src/modules/coinjoin/coinjoin.h
@@ -42,6 +42,11 @@ static const unsigned int COINJOIN_FEE_DENOM_THRESHOLD      = 9;
 //! number of denoms each size before new ones are created
 static const unsigned int COINJOIN_DENOM_WINDOW             = 3;
 
+//! depth boundaries
+static const int MIN_COINJOIN_DEPTH              = 1;
+static const int DEFAULT_COINJOIN_DEPTH          = 2;
+static const int MAX_COINJOIN_DEPTH              = 3;
+
 // pool responses
 enum PoolMessage {
     ERR_ALREADY_HAVE,

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -48,11 +48,11 @@ std::string CTxIn::ToString() const
     return str;
 }
 
-CTxOut::CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn, int nRoundsIn)
+CTxOut::CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn, int nDepthIn)
 {
     nValue = nValueIn;
     scriptPubKey = scriptPubKeyIn;
-    nRounds = nRoundsIn;
+    nDepth = nDepthIn;
 }
 
 std::string CTxOut::ToString() const

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -139,14 +139,14 @@ class CTxOut
 public:
     CAmount nValue;
     CScript scriptPubKey;
-    int nRounds;
+    int nDepth;
 
     CTxOut()
     {
         SetNull();
     }
 
-    CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn, int nRoundsIn = -10);
+    CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn, int nDepthIn = -10);
 
     ADD_SERIALIZE_METHODS;
 
@@ -160,7 +160,7 @@ public:
     {
         nValue = -1;
         scriptPubKey.clear();
-        nRounds = -10; // an initial value, should be no way to get this by calculations
+        nDepth = -10; // an initial value, should be no way to get this by calculations
     }
 
     bool IsNull() const
@@ -172,7 +172,7 @@ public:
     {
         return (a.nValue       == b.nValue &&
                 a.scriptPubKey == b.scriptPubKey &&
-                a.nRounds      == b.nRounds);
+                a.nDepth      == b.nDepth);
     }
 
     friend bool operator!=(const CTxOut& a, const CTxOut& b)

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -422,8 +422,8 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
             item->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
         else {
             coinControl()->Select(outpt);
-            int nRounds = model->wallet().getCappedOutpointCoinJoinRounds(outpt);
-            if (coinControl()->fUseCoinJoin && nRounds < model->wallet().getPSRounds()) {
+            int nDepth = model->node().analyzeCoin(outpt);
+            if (coinControl()->fUseCoinJoin && nDepth < model->wallet().getCJDepth()) {
                 QMessageBox::warning(this, windowTitle(),
                     tr("Non-anonymized input selected. <b>CoinJoin will be disabled.</b><br><br>If you still want to use CoinJoin, please deselect all non-nonymized inputs first and then check CoinJoin checkbox again."),
                     QMessageBox::Ok, QMessageBox::Ok);
@@ -744,11 +744,11 @@ void CoinControlDialog::updateView()
             itemOutput->setData(COLUMN_DATE, Qt::UserRole, QVariant((qlonglong)out.time));
 
             // CoinJoin rounds
-            int nRounds = model->wallet().getCappedOutpointCoinJoinRounds(output);
+            int nDepth = model->node().analyzeCoin(output);
 
-            if (nRounds >= 0) itemOutput->setText(COLUMN_COINJOIN_ROUNDS, QString::number(nRounds));
+            if (nDepth >= 0) itemOutput->setText(COLUMN_COINJOIN_ROUNDS, QString::number(nDepth));
             else itemOutput->setText(COLUMN_COINJOIN_ROUNDS, QString::fromStdString("n/a"));
-            itemOutput->setData(COLUMN_COINJOIN_ROUNDS, Qt::UserRole, QVariant((qlonglong)nRounds));
+            itemOutput->setData(COLUMN_COINJOIN_ROUNDS, Qt::UserRole, QVariant((qlonglong)nDepth));
 
             // confirmations
             itemOutput->setText(COLUMN_CONFIRMATIONS, QString::number(out.depth_in_main_chain));

--- a/src/qt/coinjoinconfig.cpp
+++ b/src/qt/coinjoinconfig.cpp
@@ -35,13 +35,13 @@ void CoinJoinConfig::setModel(WalletModel *_model)
 
 void CoinJoinConfig::clickBasic()
 {
-    configure(true, 1000, 2);
+    configure(true, 1000, 1);
 
     QString strAmount(BitcoinUnits::formatWithUnit(
         model->getOptionsModel()->getDisplayUnit(), 1000 * COIN));
     QMessageBox::information(this, tr("CoinJoin Configuration"),
         tr(
-            "CoinJoin was successfully set to basic (%1 and 2 rounds). You can change this at any time by opening Chaincoin's configuration screen."
+            "CoinJoin was successfully set to basic (%1 and 1 parent). You can change this at any time by opening Chaincoin's configuration screen."
         ).arg(strAmount)
     );
 
@@ -50,13 +50,13 @@ void CoinJoinConfig::clickBasic()
 
 void CoinJoinConfig::clickHigh()
 {
-    configure(true, 1000, 8);
+    configure(true, 1000, 2);
 
     QString strAmount(BitcoinUnits::formatWithUnit(
         model->getOptionsModel()->getDisplayUnit(), 1000 * COIN));
     QMessageBox::information(this, tr("CoinJoin Configuration"),
         tr(
-            "CoinJoin was successfully set to high (%1 and 8 rounds). You can change this at any time by opening Chaincoin's configuration screen."
+            "CoinJoin was successfully set to high (%1 and 2 parents). You can change this at any time by opening Chaincoin's configuration screen."
         ).arg(strAmount)
     );
 
@@ -65,13 +65,13 @@ void CoinJoinConfig::clickHigh()
 
 void CoinJoinConfig::clickMax()
 {
-    configure(true, 1000, 16);
+    configure(true, 1000, 3);
 
     QString strAmount(BitcoinUnits::formatWithUnit(
         model->getOptionsModel()->getDisplayUnit(), 1000 * COIN));
     QMessageBox::information(this, tr("CoinJoin Configuration"),
         tr(
-            "CoinJoin was successfully set to maximum (%1 and 16 rounds). You can change this at any time by opening Chaincoin's configuration screen."
+            "CoinJoin was successfully set to maximum (%1 and 3 parents). You can change this at any time by opening Chaincoin's configuration screen."
         ).arg(strAmount)
     );
 
@@ -82,7 +82,7 @@ void CoinJoinConfig::configure(bool enabled, int coins, int rounds) {
 
     QSettings settings;
 
-    settings.setValue("nCoinJoinRounds", rounds);
+    settings.setValue("nCoinJoinDepth", rounds);
     settings.setValue("nCoinJoinAmount", coins);
 
     model->coinJoinConfigChanged(rounds, coins);

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -418,7 +418,7 @@
       <bool>false</bool>
      </property>
      <property name="columnCount">
-      <number>7</number>
+      <number>11</number>
      </property>
      <attribute name="headerShowSortIndicator" stdset="0">
       <bool>true</bool>
@@ -448,7 +448,7 @@
      </column>
      <column>
       <property name="text">
-       <string>PS Rounds</string>
+       <string>CJ! Depth</string>
       </property>
      </column>
      <column>

--- a/src/qt/forms/coinjoinconfig.ui
+++ b/src/qt/forms/coinjoinconfig.ui
@@ -75,7 +75,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>Use 2 separate masternodes to mix funds up to 1000 CHC</string>
+    <string>Use 1 masternode</string>
    </property>
   </widget>
   <widget class="QLabel" name="label_3">
@@ -88,7 +88,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>Use 8 separate masternodes to mix funds up to 1000 CHC</string>
+    <string>Use 2 separate masternodes</string>
    </property>
   </widget>
   <widget class="QLabel" name="label_4">
@@ -101,7 +101,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>Use 16 separate masternodes</string>
+    <string>Use 3 separate masternodes</string>
    </property>
   </widget>
   <widget class="QLabel" name="label_6">
@@ -114,7 +114,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>This option is the quickest and will cost about ~0.025 CHC to anonymize 1000 CHC</string>
+    <string>This option is the quickest and will cost about ~0.01 CHC to anonymize 1000 CHC</string>
    </property>
   </widget>
   <widget class="QLabel" name="label_7">
@@ -127,7 +127,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>This option is moderately fast and will cost about 0.05 CHC to anonymize 1000 CHC</string>
+    <string>This option is moderately fast and will cost about ~0.02 CHC to anonymize 1000 CHC</string>
    </property>
   </widget>
   <widget class="QLabel" name="label_8">
@@ -140,7 +140,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>This is the slowest and most secure option. Using maximum anonymity will cost</string>
+    <string>This is the slowest and most secure option. Using maximum anonymity will cost about</string>
    </property>
   </widget>
   <widget class="QLabel" name="label_9">
@@ -153,7 +153,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>0.1 CHC per 1000 CHC you anonymize.</string>
+    <string>~0.3 CHC per 1000 CHC you anonymize.</string>
    </property>
   </widget>
   <widget class="Line" name="line">

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -267,20 +267,20 @@
             <string>This setting determines the amount of individual masternodes that an input will be anonymized through.&lt;br/&gt;More rounds of anonymization gives a higher degree of privacy, but also costs more in fees.</string>
            </property>
            <property name="text">
-            <string>CoinJoin rounds to use</string>
+            <string>CoinJoin depth to use</string>
            </property>
           </widget>
          </item>
          <item>
           <widget class="QSpinBox" name="coinJoinRounds">
            <property name="minimum">
-            <number>2</number>
+            <number>1</number>
            </property>
            <property name="maximum">
-            <number>16</number>
+            <number>3</number>
            </property>
            <property name="value">
-            <number>4</number>
+            <number>3</number>
            </property>
           </widget>
          </item>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -551,14 +551,14 @@
             <item row="3" column="0">
              <widget class="QLabel" name="labelAmountAndRoundsText">
               <property name="text">
-               <string>Amount and Rounds:</string>
+               <string>Amount and Depth:</string>
               </property>
              </widget>
             </item>
             <item row="3" column="1">
              <widget class="QLabel" name="labelAmountRounds">
               <property name="text">
-               <string>0 CHC / 0 Rounds</string>
+               <string>0 CHC / Depth: 0</string>
               </property>
              </widget>
             </item>

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -138,10 +138,10 @@ void OptionsModel::Init(bool resetSettings)
         addOverriddenOption("-spendzeroconfchange");
 
     // CoinJoin
-    if (!settings.contains("nCoinJoinRounds"))
-        settings.setValue("nCoinJoinRounds", 2);
-    nCoinJoinRounds = settings.value("nCoinJoinRounds").toInt();
-    if (!m_node.softSetArg("-privatesendrounds", settings.value("nCoinJoinRounds").toString().toStdString()))
+    if (!settings.contains("nCoinJoinDepth"))
+        settings.setValue("nCoinJoinDepth", 2);
+    nCoinJoinDepth = settings.value("nCoinJoinDepth").toInt();
+    if (!m_node.softSetArg("-privatesendrounds", settings.value("nCoinJoinDepth").toString().toStdString()))
         addOverriddenOption("-privatesendrounds");
 
     if (!settings.contains("nCoinJoinAmount"))
@@ -321,7 +321,7 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case LowKeysWarning:
             return settings.value("fLowKeysWarning");
         case CoinJoinRounds:
-            return settings.value("nCoinJoinRounds");
+            return settings.value("nCoinJoinDepth");
         case CoinJoinAmount:
             return settings.value("nCoinJoinAmount");
 #endif
@@ -458,17 +458,17 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             settings.setValue("fLowKeysWarning", value);
             break;
         case CoinJoinRounds:
-            if (settings.value("nCoinJoinRounds") != value) {
-                settings.setValue("nCoinJoinRounds", value);
-                nCoinJoinRounds = value.toInt();
-                Q_EMIT coinJoinConfigChanged(nCoinJoinRounds, nCoinJoinAmount);
+            if (settings.value("nCoinJoinDepth") != value) {
+                settings.setValue("nCoinJoinDepth", value);
+                nCoinJoinDepth = value.toInt();
+                Q_EMIT coinJoinConfigChanged(nCoinJoinDepth, nCoinJoinAmount);
             }
             break;
         case CoinJoinAmount:
             if (settings.value("nCoinJoinAmount") != value) {
                 settings.setValue("nCoinJoinAmount", value);
                 nCoinJoinAmount = value.toInt();
-                Q_EMIT coinJoinConfigChanged(nCoinJoinRounds, nCoinJoinAmount);
+                Q_EMIT coinJoinConfigChanged(nCoinJoinDepth, nCoinJoinAmount);
             }
             break;
 #endif

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -83,7 +83,7 @@ public:
     bool getProxySettings(QNetworkProxy& proxy) const;
     bool getCoinControlFeatures() const { return fCoinControlFeatures; }
     bool getShowAdvancedPSUI() const { return fShowAdvancedPSUI; }
-    int getCoinJoinRounds() const { return nCoinJoinRounds; }
+    int getCoinJoinRounds() const { return nCoinJoinDepth; }
     int getCoinJoinAmount() const { return nCoinJoinAmount; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
 
@@ -104,7 +104,7 @@ private:
     QString strThirdPartyTxUrls;
     bool fCoinControlFeatures;
     bool fShowAdvancedPSUI;
-    int nCoinJoinRounds;
+    int nCoinJoinDepth;
     int nCoinJoinAmount;
     /* settings that were overriden by command-line */
     QString strOverriddenByCommandLine;

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -50,7 +50,7 @@ private:
     ClientModel *clientModel;
     WalletModel *walletModel;
     interfaces::WalletBalances m_balances;
-    interfaces::CoinJoinStatus m_privsendstatus;
+    interfaces::CoinJoinStatus m_coinjoinstatus;
     int nDisplayUnit;
     bool fShowAdvancedPSUI;
 

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -124,12 +124,12 @@ HelpMessageDialog::HelpMessageDialog(interfaces::Node& node, QWidget *parent, He
 <h3>CoinJoin Basics</h3> \
 CoinJoin gives you true financial privacy by obscuring the origins of your funds. \
 All the Chaincoin in your wallet is comprised of different \"inputs\" which you can think of as separate, discrete coins.<br> \
-CoinJoin uses an innovative process to mix your inputs with the inputs of two  or more other people, without having your coins ever leave your wallet. \
+CoinJoin uses an improved process to mix your inputs with the inputs of two  or more other people, without having your coins ever leave your wallet. \
 You retain control of your money at all times.<hr> \
 <b>The CoinJoin process works like this:</b>\
 <ol type=\"1\"> \
 <li>CoinJoin begins by breaking your transaction inputs down into standard denominations. \
-These denominations are 0.01 CHC, 0.1 CHC, 1 CHC and 10 CHC -- sort of like the paper money you use every day.</li> \
+The base denomination is 1.024 CHC which can be multiplied or divided by 2 -- sort of like the paper money you use every day.</li> \
 <li>Your wallet then sends requests to specially configured software nodes on the network, called \"masternodes.\" \
 These masternodes are informed then that you are interested in mixing a certain denomination. \
 No identifiable information is sent to the masternodes, so they never know \"who\" you are.</li> \
@@ -137,7 +137,8 @@ No identifiable information is sent to the masternodes, so they never know \"who
 The masternode mixes up the inputs and instructs all three users' wallets to pay the now-transformed input back to themselves. \
 Your wallet pays that denomination directly to itself, but in a different address (called a change address).</li> \
 <li>In order to fully obscure your funds, your wallet must repeat this process a number of times with each denomination. \
-Each time the process is completed, it's called a \"round.\" Each round of CoinJoin makes it exponentially more difficult to determine where your funds originated.</li> \
+Each time the process is completed, it's exponentially harder to trace the funds used. \
+The origin of the (non-denominated) input is called the \"root.\" The wallet is analyzing the \"depth\" of the root and starts the process whenever required.</li> \
 <li>This mixing process happens in the background without any intervention on your part. When you wish to make a transaction, \
 your funds will already be anonymized. No additional waiting is required.</li> \
 </ol> <hr>\

--- a/src/validation.h
+++ b/src/validation.h
@@ -284,6 +284,12 @@ CAmount GetMasternodePayment(int nHeight, CAmount blockValue);
 /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */
 double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex* pindex);
 
+/** Return the average CoinJoin depth of an outpoint. */
+int AnalyzeCoin(const COutPoint& outpoint);
+
+/** Recursively calculate the depth of obscuring a single outpoint. */
+bool FindRoot(const COutPoint& outpoint, std::vector<int>& vRoots, int nDepth = 1);
+
 /** Calculate the amount of disk space the block & undo files currently use */
 uint64_t CalculateCurrentUsage();
 

--- a/src/wallet/coinjoin_client.cpp
+++ b/src/wallet/coinjoin_client.cpp
@@ -670,7 +670,7 @@ bool CCoinJoinClientManager::IsMixingRequired(std::vector<std::pair<CTxIn, CTxOu
                 if (it->second.nValue == denom) {
                     count++;
                     nTotal -= denom;
-                    if (!nLiquidityProvider && it->second.nRounds >= nCoinJoinRounds) {
+                    if (!nLiquidityProvider && it->second.nDepth >= nCoinJoinDepth) {
                         vecAmounts.push_back(it->second.nValue);
                         portfolio.erase(it--);
                     }
@@ -683,8 +683,8 @@ bool CCoinJoinClientManager::IsMixingRequired(std::vector<std::pair<CTxIn, CTxOu
 
     // all in bounds so check if there's something to obscure
     for(std::vector<std::pair<CTxIn, CTxOut> >::iterator it = portfolio.begin(); it != portfolio.end(); it++) {
-        int rounds = nLiquidityProvider ? MAX_COINJOIN_ROUNDS : nCoinJoinRounds;
-        if (it->second.nRounds < rounds) {
+        int depth = nLiquidityProvider ? MAX_COINJOIN_DEPTH + 1 : nCoinJoinDepth;
+        if (it->second.nDepth < depth) {
             fMixOnly = true;
         } else {
             LOCK(m_wallet->cs_wallet);
@@ -707,7 +707,7 @@ bool CCoinJoinClientManager::IsMixingRequired(std::vector<std::pair<CTxIn, CTxOu
             if (it->second.nValue > denom) break;
             if (it->second.nValue == denom) {
                 count++;
-                if (count > threshold) {
+                if (count > threshold && it->second.nDepth >= MAX_COINJOIN_DEPTH) {
                     LOCK(m_wallet->cs_wallet);
                     m_wallet->UnlockCoin(it->first.prevout);
                     portfolio.erase(it--);
@@ -983,7 +983,7 @@ bool CCoinJoinClientSession::AddFeesAndLocktime(std::vector<CAmount>& vecAmounts
 
         // not enough selected? try to add additional inputs
         int n = nFeeNeeded % COINJOIN_LOW_DENOM  == 0 ? nFeeNeeded / COINJOIN_LOW_DENOM : nFeeNeeded / COINJOIN_LOW_DENOM + 1;
-        selected = m_wallet_session->SelectJoinCoins(n * 2 * COINJOIN_LOW_DENOM, n * 2 * COINJOIN_LOW_DENOM, tmp_select, 0, MAX_COINJOIN_ROUNDS);
+        selected = m_wallet_session->SelectJoinCoins(n * 2 * COINJOIN_LOW_DENOM, n * 2 * COINJOIN_LOW_DENOM, tmp_select, 0, MAX_COINJOIN_DEPTH);
         for (std::vector<std::pair<CTxIn, CTxOut> >::iterator it = tmp_select.begin(); it != tmp_select.end(); it++) {
             if (it->second.nValue != COINJOIN_LOW_DENOM) {
                 LogPrint(BCLog::CJOIN, "%s CCoinJoinClientSession::AddFeesAndLocktime --- no inputs available for fees, trying to reduce outputs.\n", m_wallet_session->GetDisplayName());
@@ -1227,7 +1227,7 @@ void CCoinJoinClientManager::CoinJoin()
     bool fMixOnly = false;
 
     // lock the coins we are going to use early
-    if (!m_wallet->SelectJoinCoins(COINJOIN_LOW_DENOM, nBalanceNeedsAnonymized, portfolio, 0, MAX_COINJOIN_ROUNDS)) {
+    if (!m_wallet->SelectJoinCoins(COINJOIN_LOW_DENOM, nBalanceNeedsAnonymized, portfolio, 0, MAX_COINJOIN_DEPTH)) {
         // this should never happen
         LogPrintf("%s CCoinJoinClientManager::CoinJoin -- Can't mix: no compatible inputs found!\n", m_wallet->GetDisplayName());
         fActive = false;

--- a/src/wallet/coinjoin_client.h
+++ b/src/wallet/coinjoin_client.h
@@ -16,14 +16,11 @@ class CReserveKey;
 class CWallet;
 class CConnman;
 
-static const int MIN_COINJOIN_ROUNDS             = 2;
 static const int MIN_COINJOIN_AMOUNT             = 2;
 static const int MIN_COINJOIN_LIQUIDITY          = 0;
 static const int MAX_COINJOIN_SESSIONS           = 21;
-static const int MAX_COINJOIN_ROUNDS             = 32;
 static const int MAX_COINJOIN_AMOUNT             = MAX_MONEY / COIN;
 static const int MAX_COINJOIN_LIQUIDITY          = 100;
-static const int DEFAULT_COINJOIN_ROUNDS         = 4;
 static const int DEFAULT_COINJOIN_AMOUNT         = 1000;
 static const int DEFAULT_COINJOIN_LIQUIDITY      = 0;
 
@@ -205,7 +202,7 @@ private:
 
 public:
     std::atomic_bool fActive;
-    int nCoinJoinRounds;
+    int nCoinJoinDepth;
     int nCoinJoinAmount;
     int nLiquidityProvider;
     bool fEnableCoinJoin;
@@ -223,7 +220,7 @@ public:
         strAutoCoinJoinResult(),
         nCachedBlockHeight(0),
         fActive(false),
-        nCoinJoinRounds(DEFAULT_COINJOIN_ROUNDS),
+        nCoinJoinDepth(DEFAULT_COINJOIN_DEPTH),
         nCoinJoinAmount(DEFAULT_COINJOIN_AMOUNT),
         nLiquidityProvider(DEFAULT_COINJOIN_LIQUIDITY),
         fEnableCoinJoin(false),

--- a/src/wallet/coinjoin_client.h
+++ b/src/wallet/coinjoin_client.h
@@ -23,7 +23,7 @@ static const int MAX_COINJOIN_SESSIONS           = 21;
 static const int MAX_COINJOIN_ROUNDS             = 32;
 static const int MAX_COINJOIN_AMOUNT             = MAX_MONEY / COIN;
 static const int MAX_COINJOIN_LIQUIDITY          = 100;
-static const int DEFAULT_COINJOIN_ROUNDS         = 8;
+static const int DEFAULT_COINJOIN_ROUNDS         = 4;
 static const int DEFAULT_COINJOIN_AMOUNT         = 1000;
 static const int DEFAULT_COINJOIN_LIQUIDITY      = 0;
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -67,7 +67,7 @@ void WalletInit::AddWalletOptions() const
                                " (1 = keep tx meta data e.g. payment request information, 2 = drop tx meta data)", false, OptionsCategory::WALLET);
 
     gArgs.AddArg("-enableprivatesend=<n>", strprintf(_("Enable use of automated CoinJoin for funds stored in this wallet (0-1, default: %u)"), 0), false, OptionsCategory::WALLET);
-    gArgs.AddArg("-privatesendrounds=<n>", strprintf(_("Use N separate masternodes for each denominated input to mix funds (%u-%u, default: %u)"), MIN_COINJOIN_ROUNDS, MAX_COINJOIN_ROUNDS, DEFAULT_COINJOIN_ROUNDS), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-privatesendrounds=<n>", strprintf(_("Use N separate masternodes for each denominated input to mix funds (%u-%u, default: %u)"), MIN_COINJOIN_DEPTH, MAX_COINJOIN_DEPTH, DEFAULT_COINJOIN_DEPTH), false, OptionsCategory::WALLET);
     gArgs.AddArg("-privatesendamount=<n>", strprintf(_("Keep N CHC anonymized (default: %u)"), DEFAULT_COINJOIN_AMOUNT), false, OptionsCategory::WALLET);
     gArgs.AddArg("-liquidityprovider=<n>", strprintf(_("Provide liquidity to CoinJoin by infrequently mixing coins on a continual basis (%u-%u, default: %u, 1=very frequent, high fees, 100=very infrequent, low fees)"), MIN_COINJOIN_LIQUIDITY, MAX_COINJOIN_LIQUIDITY, DEFAULT_COINJOIN_LIQUIDITY), false, OptionsCategory::WALLET);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2939,7 +2939,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
             entry.pushKV("desc", descriptor->ToString());
         }
         entry.pushKV("safe", out.fSafe);
-        entry.pushKV("ps_rounds", pwallet->GetCappedOutpointCoinJoinRounds(COutPoint(out.tx->GetHash(), out.i)));
+        entry.pushKV("cj_depth", pwallet->chain().analyzeCoin(COutPoint(out.tx->GetHash(), out.i)));
         results.push_back(entry);
     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -551,7 +551,7 @@ public:
     // having to resolve the issue of member access into incomplete type CWallet.
     CAmount GetAvailableCredit(interfaces::Chain::Lock& locked_chain, bool fUseCache=true, const isminefilter& filter=ISMINE_SPENDABLE) const NO_THREAD_SAFETY_ANALYSIS;
     CAmount GetImmatureWatchOnlyCredit(interfaces::Chain::Lock& locked_chain, const bool fUseCache=true) const;
-    CAmount GetDenominatedCredit(interfaces::Chain::Lock& locked_chain, int nCoinJoinRounds=0, bool fUseCache=true) const;
+    CAmount GetDenominatedCredit(interfaces::Chain::Lock& locked_chain, int nCoinJoinDepth=0, bool fUseCache=true) const;
     CAmount GetChange() const;
 
     // Get the marginal bytes if spending the specified output from this transaction
@@ -895,20 +895,13 @@ public:
         std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet, const CoinSelectionParams& coin_selection_params, bool& bnb_used) const;
 
     // Coin selection
-    bool SelectJoinCoins(CAmount nValueMin, CAmount nValueMax, std::vector<std::pair<CTxIn, CTxOut> >& mtxPairRet, int nCoinJoinRoundsMin, int nCoinJoinRoundsMax) const;
+    bool SelectJoinCoins(CAmount nValueMin, CAmount nValueMax, std::vector<std::pair<CTxIn, CTxOut> >& mtxPairRet, int nCoinJoinDepthMin, int nCoinJoinDepthMax) const;
     bool SelectCoinsGroupedByAddresses(std::vector<CompactTallyItem>& vecTallyRet, bool fSkipDenominated = true) const;
 
     /// Get 1000CHC output and keys which can be used for the Masternode
     bool GetMasternodeOutpointAndKeys(COutPoint& outpointRet, CTxDestination &destRet, CPubKey& pubKeyRet, CKey& keyRet, const std::string& strTxHash = "", const std::string& strOutputIndex = "");
     /// Extract txin information and keys from output
     bool GetOutpointAndKeysFromOutput(const COutput& out, COutPoint& outpointRet, CTxDestination &destRet, CPubKey& pubKeyRet, CKey& keyRet);
-
-    int  CountInputsWithAmount(CAmount nInputAmount);
-
-    // get the CoinJoin chain depth for a given input
-    int GetRealOutpointCoinJoinRounds(const COutPoint& outpoint, int nRounds = 0) const;
-    // respect current settings
-    int GetCappedOutpointCoinJoinRounds(const COutPoint& outpoint) const;
 
     bool IsDenominated(const COutPoint& outpoint) const;
 


### PR DESCRIPTION
nDepth is calculated as an average over all parent transactions and replaces nRounds