### PR TITLE
several fixes, including

### DIFF
--- a/src/modules/masternode/masternode_sync.cpp
+++ b/src/modules/masternode/masternode_sync.cpp
@@ -102,7 +102,7 @@ void CMasternodeSync::SwitchToNextAsset(CConnman* connman)
 std::string CMasternodeSync::GetSyncStatus()
 {
     switch (masternodeSync.nRequestedMasternodeAssets) {
-        case MASTERNODE_SYNC_INITIAL:       return _("Synchroning blockchain...");
+        case MASTERNODE_SYNC_INITIAL:       return _("Synchronizing blockchain...");
         case MASTERNODE_SYNC_WAITING:       return _("Synchronization pending...");
         case MASTERNODE_SYNC_LIST:          return _("Synchronizing masternodes...");
         case MASTERNODE_SYNC_MNW:           return _("Synchronizing masternode payments...");

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -572,7 +572,7 @@
             <item row="4" column="1">
              <widget class="QLabel" name="labelSubmittedDenom">
               <property name="toolTip">
-               <string>The denominations you submitted to the Masternode.&lt;br&gt;To mix, other users must submit the exact same denominations.</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The denominations you submitted to the Masternode.&lt;br/&gt;To mix, other users must submit matching denominations (one of the amounts to be exactly the same).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="text">
                <string>n/a</string>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4881,16 +4881,19 @@ int AnalyzeCoin(const COutPoint& outpoint)
     CTransactionRef tx;
     uint256 hash_block;
 
+    // return early if we have it
+    std::map<uint256, std::vector<CTxOut> >::iterator mdwi = mDenomTx.find(hash);
+
+    if (mdwi != mDenomTx.end() && mdwi->second[nout].nDepth != -10) {
+        return mdwi->second[nout].nDepth;
+    }
+
     if(GetTransaction(hash, tx, Params().GetConsensus(), hash_block))
     {
-        std::map<uint256, std::vector<CTxOut> >::iterator mdwi = mDenomTx.find(hash);
         if (mdwi == mDenomTx.end()) {
             // not known yet, let's add it
             LogPrint(BCLog::CJOIN, "[chain] AnalyzeCoin INSERTING %s\n", hash.ToString());
             mDenomTx.emplace(hash, std::vector<CTxOut>(tx->vout));
-        } else if (mdwi->second[nout].nDepth != -10) {
-            // found and it's not an initial value, just return it
-            return mdwi->second[nout].nDepth;
         }
 
         mdwi = mDenomTx.find(hash);

--- a/src/wallet/coinjoin_client.cpp
+++ b/src/wallet/coinjoin_client.cpp
@@ -1182,7 +1182,7 @@ void CCoinJoinClientManager::CoinJoin()
         return;
     }
 
-    if (nBalanceNeedsDenom >= COINJOIN_LOW_DENOM) {
+    if (nBalanceNeedsDenom >= COINJOIN_LOW_DENOM * COINJOIN_FEE_DENOM_THRESHOLD) {
         strAutoCoinJoinResult = _("Creating denominated outputs.");
         if (!CreateDenominated(nBalanceNeedsDenom)) {
             strAutoCoinJoinResult = _("Failed to create denominated outputs.");
@@ -1231,12 +1231,11 @@ void CCoinJoinClientManager::CoinJoin()
 
     // lock the coins we are going to use early
     if (!m_wallet->SelectJoinCoins(COINJOIN_LOW_DENOM, nBalanceDenominated, portfolio, 0, MAX_COINJOIN_DEPTH)) {
-        // this should never happen
         LogPrintf("%s CCoinJoinClientManager::CoinJoin -- Can't mix: no compatible inputs found!\n", m_wallet->GetDisplayName());
         fActive = false;
-
         return;
     }
+
     if (IsMixingRequired(portfolio, vecAmounts, fMixOnly)) {
         for (const auto& txin : portfolio) {
             LOCK(m_wallet->cs_wallet);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2939,7 +2939,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
             entry.pushKV("desc", descriptor->ToString());
         }
         entry.pushKV("safe", out.fSafe);
-        entry.pushKV("cj_depth", pwallet->chain().analyzeCoin(COutPoint(out.tx->GetHash(), out.i)));
+        // temporarily disabled due to lock order entry.pushKV("cj_depth", pwallet->chain().analyzeCoin(COutPoint(out.tx->GetHash(), out.i)));
         results.push_back(entry);
     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -551,7 +551,7 @@ public:
     // having to resolve the issue of member access into incomplete type CWallet.
     CAmount GetAvailableCredit(interfaces::Chain::Lock& locked_chain, bool fUseCache=true, const isminefilter& filter=ISMINE_SPENDABLE) const NO_THREAD_SAFETY_ANALYSIS;
     CAmount GetImmatureWatchOnlyCredit(interfaces::Chain::Lock& locked_chain, const bool fUseCache=true) const;
-    CAmount GetDenominatedCredit(interfaces::Chain::Lock& locked_chain, int nCoinJoinDepth=0, bool fUseCache=true) const;
+    CAmount GetDenominatedCredit(interfaces::Chain::Lock& locked_chain, int nCoinJoinDepth=0, bool fUseCache=true) const NO_THREAD_SAFETY_ANALYSIS;
     CAmount GetChange() const;
 
     // Get the marginal bytes if spending the specified output from this transaction

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -903,8 +903,6 @@ public:
     /// Extract txin information and keys from output
     bool GetOutpointAndKeysFromOutput(const COutput& out, COutPoint& outpointRet, CTxDestination &destRet, CPubKey& pubKeyRet, CKey& keyRet);
 
-    bool IsDenominated(const COutPoint& outpoint) const;
-
     bool IsSpent(interfaces::Chain::Lock& locked_chain, const uint256& hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     std::vector<OutputGroup> GroupOutputs(const std::vector<COutput>& outputs, bool single_coin) const;
 


### PR DESCRIPTION

temporarily disable coin analysis on rpc (lock order)
avoid denominating after each round
avoid cs_main lock if we have already cached the nDepth