### PR TITLE
fixes and cleanups

### DIFF
--- a/src/modules/coinjoin/coinjoin.cpp
+++ b/src/modules/coinjoin/coinjoin.cpp
@@ -316,12 +316,12 @@ std::string CCoinJoin::GetMessageByID(PoolMessage nMessageID)
         return _("Entries are full.");
     case ERR_INVALID_OUT:
         return _("Not compatible with existing transactions.");
-    case ERR_FEES:
-        return _("Fee error.");
+    case ERR_MN_FEES:
+        return _("Missing or high masternode fees.");
     case ERR_INVALID_INPUT:
         return _("Input is not valid.");
-    case ERR_INVALID_SCRIPT:
-        return _("Invalid script detected.");
+    case ERR_FEES:
+        return _("Included fees too high or too low.");
     case ERR_INVALID_TX:
         return _("Transaction not valid.");
     case ERR_MAXIMUM:
@@ -330,10 +330,6 @@ std::string CCoinJoin::GetMessageByID(PoolMessage nMessageID)
         return _("Not in the Masternode list.");
     case ERR_MODE:
         return _("Incompatible mode.");
-    case ERR_NON_STANDARD_PUBKEY:
-        return _("Non-standard public key detected.");
-    case ERR_NOT_A_MN:
-        return _("This is not a Masternode."); // not used
     case ERR_QUEUE_FULL:
         return _("Masternode queue is full.");
     case ERR_RECENT:

--- a/src/modules/coinjoin/coinjoin.h
+++ b/src/modules/coinjoin/coinjoin.h
@@ -55,15 +55,13 @@ enum PoolMessage {
     ERR_DENOM,
     ERR_ENTRIES_FULL,
     ERR_INVALID_OUT,
-    ERR_FEES,
+    ERR_MN_FEES,
     ERR_INVALID_INPUT,
-    ERR_INVALID_SCRIPT,
+    ERR_FEES,
     ERR_INVALID_TX,
     ERR_MAXIMUM,
     ERR_MN_LIST,
     ERR_MODE,
-    ERR_NON_STANDARD_PUBKEY,
-    ERR_NOT_A_MN, // not used
     ERR_QUEUE_FULL,
     ERR_RECENT,
     ERR_SESSION,
@@ -126,6 +124,12 @@ public:
         READWRITE(nSessionID);
         READWRITE(psbtx);
     }
+
+    friend bool operator==(const CCoinJoinEntry& a, const CCoinJoinEntry& b)
+    {
+        return a.nSessionID == b.nSessionID && a.psbtx.tx->GetHash() == b.psbtx.tx->GetHash();
+    }
+
 };
 
 

--- a/src/modules/coinjoin/coinjoin_server.cpp
+++ b/src/modules/coinjoin/coinjoin_server.cpp
@@ -186,7 +186,7 @@ void CCoinJoinServer::ProcessModuleMessage(CNode* pfrom, const std::string& strC
 
         if (nMNfee < nFee) {
             LogPrintf("CJTXIN -- missing masternode fees!\n");
-            PushStatus(pfrom, STATUS_REJECTED, ERR_FEES, connman);
+            PushStatus(pfrom, STATUS_REJECTED, ERR_MN_FEES, connman);
             return;
         }
 
@@ -566,6 +566,15 @@ bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entryNew, PoolMessage& nMes
         LogPrint(BCLog::CJOIN, "CCoinJoinServer::AddEntry -- entries is full!\n");
         nMessageIDRet = ERR_ENTRIES_FULL;
         return false;
+    }
+
+    LOCK(cs_coinjoin);
+    for (const auto& entry : vecEntries) {
+        if (entry == entryNew) {
+            LogPrint(BCLog::CJOIN, "CCoinJoinServer::AddEntry -- adding entry\n");
+            nMessageIDRet = ERR_ALREADY_HAVE;
+            return false;
+        }
     }
 
     vecEntries.push_back(entryNew);


### PR DESCRIPTION
process each received entry only once
improve timing when switching pool state
clean out unused error IDs
clarify fee error