### PR TITLE
make sure only participating nodes are informed about queue status up…

### DIFF
--- a/src/modules/coinjoin/coinjoin.h
+++ b/src/modules/coinjoin/coinjoin.h
@@ -16,6 +16,7 @@
 
 class CCoinJoin;
 class CConnman;
+class CNode;
 
 // denominations
 static const unsigned char COINJOIN_MAX_SHIFT = 0x0b;
@@ -197,6 +198,7 @@ public:
     bool CheckSignature(const CPubKey& pubKeyMasternode) const;
 
     bool Relay(CConnman* connman);
+    bool Push(const CService pto, CConnman* connman);
 
     /// Is this queue expired?
     bool IsExpired(int nHeightIn) const { return nHeightIn - nHeight > COINJOIN_DEFAULT_TIMEOUT; }

--- a/src/modules/coinjoin/coinjoin_server.h
+++ b/src/modules/coinjoin/coinjoin_server.h
@@ -19,6 +19,7 @@ class CCoinJoinServer : public CCoinJoinBaseSession, public CCoinJoinBaseManager
 {
 private:
     std::vector<CAmount> vecDenom;
+    CCoinJoinQueue activeQueue;
 
     bool fUnitTest;
 
@@ -35,7 +36,7 @@ private:
     void CheckPool(CConnman* connman);
 
     /// Check Session
-    bool CheckSessionMessage(PoolState state, CNode* pnode, CConnman* connman);
+    bool CheckSessionMessage(CNode* pnode, CConnman* connman);
 
     void CreateFinalTransaction(CConnman* connman);
     void CommitFinalTransaction(CConnman* connman);
@@ -65,6 +66,7 @@ private:
 public:
     CCoinJoinServer() :
         vecDenom(),
+        activeQueue(),
         fUnitTest(false),
         nCachedBlockHeight(0)
         { SetNull(); }


### PR DESCRIPTION
…dates

this also introduces a local queue for server so they don't need to loop through all active ones if they need to find or update theirs